### PR TITLE
chore: rename internal helpers for export

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,8 +3,8 @@ mod wadray_signed;
 
 use wadray::{
     BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOneable, RayZeroable,
-    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, WAD_DECIMALS, WAD_ONE, WAD_PERCENT, WAD_SCALE, Wad, WadOneable, WadZeroable,
-    wdiv_rw, wmul_rw, wmul_wr,
+    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
+    WAD_SCALE, Wad, WadOneable, WadZeroable, wdiv_rw, wmul_rw, wmul_wr,
 };
 use wadray_signed::{
     BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOneable, SignedRayZeroable, SignedWad,

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,7 +3,7 @@ mod wadray_signed;
 
 use wadray::{
     BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOneable, RayZeroable,
-    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
+    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
     WAD_SCALE, Wad, WadOneable, WadZeroable, wdiv_rw, wmul_rw, wmul_wr,
 };
 use wadray_signed::{

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,7 +3,7 @@ mod wadray_signed;
 
 use wadray::{
     BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOneable, RayZeroable,
-    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
+    rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
     WAD_SCALE, Wad, WadOneable, WadZeroable, wdiv_rw, wmul_rw, wmul_wr,
 };
 use wadray_signed::{

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -35,13 +35,13 @@ fn cast_to_u256(a: u128, b: u128) -> (u256, u256) {
 
 #[inline(always)]
 fn wmul(lhs: Wad, rhs: Wad) -> Wad {
-    Wad { val: wmul_internal(lhs.val, rhs.val) }
+    Wad { val: u128_wmul(lhs.val, rhs.val) }
 }
 
 // wmul of Wad and Ray -> Ray
 #[inline(always)]
 fn wmul_wr(lhs: Wad, rhs: Ray) -> Ray {
-    Ray { val: wmul_internal(lhs.val, rhs.val) }
+    Ray { val: u128_wmul(lhs.val, rhs.val) }
 }
 
 #[inline(always)]
@@ -51,13 +51,13 @@ fn wmul_rw(lhs: Ray, rhs: Wad) -> Ray {
 
 #[inline(always)]
 fn rmul(lhs: Ray, rhs: Ray) -> Ray {
-    Ray { val: rmul_internal(lhs.val, rhs.val) }
+    Ray { val: u128_rmul(lhs.val, rhs.val) }
 }
 
 // rmul of Wad and Ray -> Wad
 #[inline(always)]
 fn rmul_rw(lhs: Ray, rhs: Wad) -> Wad {
-    Wad { val: rmul_internal(lhs.val, rhs.val) }
+    Wad { val: u128_rmul(lhs.val, rhs.val) }
 }
 
 #[inline(always)]
@@ -67,68 +67,68 @@ fn rmul_wr(lhs: Wad, rhs: Ray) -> Wad {
 
 #[inline(always)]
 fn wdiv(lhs: Wad, rhs: Wad) -> Wad {
-    Wad { val: wdiv_internal(lhs.val, rhs.val) }
+    Wad { val: u128_wdiv(lhs.val, rhs.val) }
 }
 
 // wdiv of Ray by Wad -> Ray
 #[inline(always)]
 fn wdiv_rw(lhs: Ray, rhs: Wad) -> Ray {
-    Ray { val: wdiv_internal(lhs.val, rhs.val) }
+    Ray { val: u128_wdiv(lhs.val, rhs.val) }
 }
 
 #[inline(always)]
 fn rdiv(lhs: Ray, rhs: Ray) -> Ray {
-    Ray { val: rdiv_internal(lhs.val, rhs.val) }
+    Ray { val: u128_rdiv(lhs.val, rhs.val) }
 }
 
 // rdiv of Wad by Ray -> Wad
 #[inline(always)]
 fn rdiv_wr(lhs: Wad, rhs: Ray) -> Wad {
-    Wad { val: rdiv_internal(lhs.val, rhs.val) }
+    Wad { val: u128_rdiv(lhs.val, rhs.val) }
 }
 
 // rdiv of Wad by Wad -> Ray
 #[inline(always)]
 fn rdiv_ww(lhs: Wad, rhs: Wad) -> Ray {
-    Ray { val: rdiv_internal(lhs.val, rhs.val) }
+    Ray { val: u128_rdiv(lhs.val, rhs.val) }
 }
 
 #[inline(always)]
 fn scale_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
-    rmul_internal(lhs, rhs.val)
+    u128_rmul(lhs, rhs.val)
 }
 
 #[inline(always)]
 fn div_u128_by_ray(lhs: u128, rhs: Ray) -> u128 {
-    rdiv_internal(lhs, rhs.val)
+    u128_rdiv(lhs, rhs.val)
 }
 
 //
-// Internal helpers
+// Helpers
 //
 
 #[inline(always)]
-fn wmul_internal(lhs: u128, rhs: u128) -> u128 {
+fn u128_wmul(lhs: u128, rhs: u128) -> u128 {
     let (lhs_u256, rhs_u256) = cast_to_u256(lhs, rhs);
-    (lhs_u256 * rhs_u256 / WAD_ONE.into()).try_into().expect('wmul_internal')
+    (lhs_u256 * rhs_u256 / WAD_ONE.into()).try_into().expect('u128_wmul')
 }
 
 #[inline(always)]
-fn rmul_internal(lhs: u128, rhs: u128) -> u128 {
+fn u128_rmul(lhs: u128, rhs: u128) -> u128 {
     let (lhs_u256, rhs_u256) = cast_to_u256(lhs, rhs);
-    (lhs_u256 * rhs_u256 / RAY_ONE.into()).try_into().expect('rmul_internal')
+    (lhs_u256 * rhs_u256 / RAY_ONE.into()).try_into().expect('u128_rmul')
 }
 
 #[inline(always)]
-fn wdiv_internal(lhs: u128, rhs: u128) -> u128 {
+fn u128_wdiv(lhs: u128, rhs: u128) -> u128 {
     let (lhs_u256, rhs_u256) = cast_to_u256(lhs, rhs);
-    ((lhs_u256 * WAD_ONE.into()) / rhs_u256).try_into().expect('wdiv_internal')
+    ((lhs_u256 * WAD_ONE.into()) / rhs_u256).try_into().expect('u128_wdiv')
 }
 
 #[inline(always)]
-fn rdiv_internal(lhs: u128, rhs: u128) -> u128 {
+fn u128_rdiv(lhs: u128, rhs: u128) -> u128 {
     let (lhs_u256, rhs_u256) = cast_to_u256(lhs, rhs);
-    ((lhs_u256 * RAY_ONE.into()) / rhs_u256).try_into().expect('rdiv_internal')
+    ((lhs_u256 * RAY_ONE.into()) / rhs_u256).try_into().expect('u128_rdiv')
 }
 
 

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,7 +1,7 @@
 use debug::PrintTrait;
 use integer::BoundedInt;
 use math::Oneable;
-use wadray::wadray::{DIFF, Ray, RAY_ONE, rdiv_internal, rmul_internal, Wad, WAD_ONE, wdiv_internal, wmul_internal};
+use wadray::wadray::{DIFF, Ray, RAY_ONE, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_ONE};
 
 const HALF_PRIME: felt252 = 1809251394333065606848661391547535052811553607665798349986546028067936010240;
 
@@ -120,7 +120,7 @@ impl SignedRaySubEq of SubEq<SignedRay> {
 impl SignedWadMul of Mul<SignedWad> {
     fn mul(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
         let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = wmul_internal(lhs.val, rhs.val);
+        let val = u128_wmul(lhs.val, rhs.val);
         SignedWad { val: val, sign: sign }
     }
 }
@@ -128,7 +128,7 @@ impl SignedWadMul of Mul<SignedWad> {
 impl SignedRayMul of Mul<SignedRay> {
     fn mul(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
         let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = rmul_internal(lhs.val, rhs.val);
+        let val = u128_rmul(lhs.val, rhs.val);
         SignedRay { val: val, sign: sign }
     }
 }
@@ -152,7 +152,7 @@ impl SignedRayMulEq of MulEq<SignedRay> {
 impl SignedWadDiv of Div<SignedWad> {
     fn div(lhs: SignedWad, rhs: SignedWad) -> SignedWad {
         let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = wdiv_internal(lhs.val, rhs.val);
+        let val = u128_wdiv(lhs.val, rhs.val);
         SignedWad { val: val, sign: sign }
     }
 }
@@ -160,7 +160,7 @@ impl SignedWadDiv of Div<SignedWad> {
 impl SignedRayDiv of Div<SignedRay> {
     fn div(lhs: SignedRay, rhs: SignedRay) -> SignedRay {
         let sign = sign_from_mul(lhs.sign, rhs.sign);
-        let val = rdiv_internal(lhs.val, rhs.val);
+        let val = u128_rdiv(lhs.val, rhs.val);
         SignedRay { val: val, sign: sign }
     }
 }


### PR DESCRIPTION
This PR renames the following functions for clarity (an contract that uses this package may need this functions) and exports them for simpler imports:
- `wdiv_internal` -> `u128_wdiv`
- `wmul_internal` -> `u128_wmul`
- `rdiv_internal` -> `u128_rdiv`
- `rmul_internal` -> `u128_rmul`

This change is intended to facilitate the main contracts repo importing this library as a Scarb dependency, because it currently relies on `wdiv_internal` and `wmul_internal`.


