### PR TITLE
feat: implement Display and Debug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.3.1"
+          scarb-version: "2.4.0"
       - run: scarb fmt --check
       - run: scarb build
 
       - uses: foundry-rs/setup-snfoundry@v2
         with:
-          starknet-foundry-version: "0.11.0"
+          starknet-foundry-version: "0.13.1"
       - run: snforge test

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,5 +2,13 @@
 version = 1
 
 [[package]]
+name = "snforge_std"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.13.1#e1412ed040d10e66be0fd84115f72a667b57a116"
+
+[[package]]
 name = "wadray"
 version = "0.1.0"
+dependencies = [
+ "snforge_std",
+]

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -8,7 +8,7 @@ source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.13.1#e14
 
 [[package]]
 name = "wadray"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "snforge_std",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadray"
 version = "0.1.0"
-cairo-version = "2.3.1"
+cairo-version = "2.4.0"
 authors = ["Lindy Labs"]
 description = "Fixed-point decimal numbers for Cairo"
 readme = "README.md"
@@ -10,10 +10,10 @@ license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
 [dependencies]
-starknet = "2.3.1"
+starknet = "2.4.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.11.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.13.1" }
 
 [lib]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/lindy-labs/wadray"
 license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
-[dependencies]
-starknet = "2.4.0"
-
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.13.1" }
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wadray"
-version = "0.1.0"
+version = "0.2.0"
 cairo-version = "2.4.0"
 authors = ["Lindy Labs"]
 description = "Fixed-point decimal numbers for Cairo"

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -318,3 +318,15 @@ fn test_zeroable() {
     assert(!ray_zero.is_non_zero(), 'Value should be 0 #9');
     assert(ray_one.is_non_zero(), 'Value should not be 0 #10');
 }
+
+
+#[test]
+fn test_display_and_debug() {
+    let w = Wad { val: 123 };
+    assert(format!("{}", w) == "123", 'Wad display');
+    assert(format!("{:?}", w) == "123", 'Wad debug');
+
+    let r = Ray { val: 456 };
+    assert(format!("{}", r) == "456", 'Ray display');
+    assert(format!("{:?}", r) == "456", 'Ray debug');
+}

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -6,27 +6,29 @@ use wadray::{
 #[test]
 fn test_add() {
     // 0 + 0 = 0
-    assert(Wad { val: 0 } + Wad { val: 0 } == Wad { val: 0 }, 'Incorrect addition #1');
+    assert_eq!(Wad { val: 0 } + Wad { val: 0 }, Wad { val: 0 }, "Incorrect addition #1");
 
     // 1 + 1 = 2
-    assert(Wad { val: 1 } + Wad { val: 1 } == Wad { val: 2 }, 'Incorrect addition #2');
+    assert_eq!(Wad { val: 1 } + Wad { val: 1 }, Wad { val: 2 }, "Incorrect addition #2");
 
     // 123456789101112 + 121110987654321 = 244567776755433
-    assert(
-        Wad { val: 123456789101112 } + Wad { val: 121110987654321 } == Wad { val: 244567776755433 },
-        'Incorrect addition #3'
+    assert_eq!(
+        Wad { val: 123456789101112 } + Wad { val: 121110987654321 },
+        Wad { val: 244567776755433 },
+        "Incorrect addition #3"
     );
 
     // 0 + 0 = 0
-    assert(Ray { val: 0 } + Ray { val: 0 } == Ray { val: 0 }, 'Incorrect addition #4');
+    assert_eq!(Ray { val: 0 } + Ray { val: 0 }, Ray { val: 0 }, "Incorrect addition #4");
 
     // 1 + 1 = 2
-    assert(Ray { val: 1 } + Ray { val: 1 } == Ray { val: 2 }, 'Incorrect addition #5');
+    assert_eq!(Ray { val: 1 } + Ray { val: 1 }, Ray { val: 2 }, "Incorrect addition #5");
 
     // 123456789101112 + 121110987654321 = 244567776755433
-    assert(
-        Ray { val: 123456789101112 } + Ray { val: 121110987654321 } == Ray { val: 244567776755433 },
-        'Incorrect addition #6'
+    assert_eq!(
+        Ray { val: 123456789101112 } + Ray { val: 121110987654321 },
+        Ray { val: 244567776755433 },
+        "Incorrect addition #6"
     );
 }
 
@@ -37,34 +39,36 @@ fn test_add_eq() {
     let b = Wad { val: 3 };
 
     a1 += b;
-    assert(a1 == a2 + b, 'Incorrect AddEq #1');
+    assert_eq!(a1, a2 + b, "Incorrect AddEq #1");
 }
 
 
 #[test]
 fn test_sub() {
     // 0 - 0 = 0
-    assert(Wad { val: 0 } - Wad { val: 0 } == Wad { val: 0 }, 'Incorrect subtraction #1');
+    assert_eq!(Wad { val: 0 } - Wad { val: 0 }, Wad { val: 0 }, "Incorrect subtraction #1");
 
     // 2 - 1 = 1
-    assert(Wad { val: 2 } - Wad { val: 1 } == Wad { val: 1 }, 'Incorrect subtraction #2');
+    assert_eq!(Wad { val: 2 } - Wad { val: 1 }, Wad { val: 1 }, "Incorrect subtraction #2");
 
     // 244567776755433 - 121110987654321 = 123456789101112
-    assert(
-        Wad { val: 244567776755433 } - Wad { val: 121110987654321 } == Wad { val: 123456789101112 },
-        'Incorrect subtraction #3'
+    assert_eq!(
+        Wad { val: 244567776755433 } - Wad { val: 121110987654321 },
+        Wad { val: 123456789101112 },
+        "Incorrect subtraction #3"
     );
 
     // 0 - 0 = 0
-    assert(Ray { val: 0 } - Ray { val: 0 } == Ray { val: 0 }, 'Incorrect subtraction #4');
+    assert_eq!(Ray { val: 0 } - Ray { val: 0 }, Ray { val: 0 }, "Incorrect subtraction #4");
 
     // 2 - 1 = 1
-    assert(Ray { val: 2 } - Ray { val: 1 } == Ray { val: 1 }, 'Incorrect subtraction #5');
+    assert_eq!(Ray { val: 2 } - Ray { val: 1 }, Ray { val: 1 }, "Incorrect subtraction #5");
 
     // 244567776755433 - 121110987654321 = 123456789101112
-    assert(
-        Ray { val: 244567776755433 } - Ray { val: 121110987654321 } == Ray { val: 123456789101112 },
-        'Incorrect subtraction #6'
+    assert_eq!(
+        Ray { val: 244567776755433 } - Ray { val: 121110987654321 },
+        Ray { val: 123456789101112 },
+        "Incorrect subtraction #6"
     );
 }
 
@@ -75,58 +79,67 @@ fn test_sub_eq() {
     let b = Wad { val: 3 };
 
     a1 -= b;
-    assert(a1 == a2 - b, 'Incorrect SubEq #1');
+    assert_eq!(a1, a2 - b, "Incorrect SubEq #1");
 }
 
 
 #[test]
 fn test_mul() {
     // 0 * 69 = 0
-    assert(Wad { val: 0 } * Wad { val: 69 } == Wad { val: 0 }, 'Incorrect Multiplication # 1');
+    assert_eq!(Wad { val: 0 } * Wad { val: 69 }, Wad { val: 0 }, "Incorrect Multiplication # 1");
 
     // 1 * 1 = 0 (truncated)
-    assert(
-        Wad { val: 1 } * Wad { val: 1 } == Wad { val: 0 }, 'Incorrect multiplication #2'
+    assert_eq!(
+        Wad { val: 1 } * Wad { val: 1 }, Wad { val: 0 }, "Incorrect multiplication #2"
     ); // Result should be truncated
 
     // 1 (wad) * 1 (wad) = 1 (wad)
-    assert(Wad { val: WAD_ONE } * Wad { val: WAD_ONE } == Wad { val: WAD_ONE }, 'Incorrect multiplication #3');
+    assert_eq!(Wad { val: WAD_ONE } * Wad { val: WAD_ONE }, Wad { val: WAD_ONE }, "Incorrect multiplication #3");
 
     // 121110987654321531059 * 1234567891011125475893 = 149519736606670187008926
-    assert(
-        Wad { val: 121110987654321531059 }
-            * Wad { val: 1234567891011125475893 } == Wad { val: 149519736606670187008926 },
-        'Incorrect multiplication #4'
+    assert_eq!(
+        Wad { val: 121110987654321531059 } * Wad { val: 1234567891011125475893 },
+        Wad { val: 149519736606670187008926 },
+        "Incorrect multiplication #4"
     );
 
     // 0 * 69 = 0
-    assert(Ray { val: 0 } * Ray { val: 69 } == Ray { val: 0 }, 'Incorrect Multiplication #5');
+    assert_eq!(Ray { val: 0 } * Ray { val: 69 }, Ray { val: 0 }, "Incorrect Multiplication #5");
 
     // 1 * 1 = 0 (truncated)
-    assert(
-        Ray { val: 1 } * Ray { val: 1 } == Ray { val: 0 }, 'Incorrect multiplication #6'
+    assert_eq!(
+        Ray { val: 1 } * Ray { val: 1 }, Ray { val: 0 }, "Incorrect multiplication #6"
     ); // Result should be truncated
 
     // 1 (ray) * 1 (ray) = 1 (ray)
-    assert(Ray { val: RAY_ONE } * Ray { val: RAY_ONE } == Ray { val: RAY_ONE }, 'Incorrect multiplication #7');
+    assert_eq!(Ray { val: RAY_ONE } * Ray { val: RAY_ONE }, Ray { val: RAY_ONE }, "Incorrect multiplication #7");
 
     // 121110987654321531059 * 1234567891011125475893 = 149519736606670 (truncated)
-    assert(
-        Ray { val: 121110987654321531059 } * Ray { val: 1234567891011125475893 } == Ray { val: 149519736606670 },
-        'Incorrect multiplication #8'
+    assert_eq!(
+        Ray { val: 121110987654321531059 } * Ray { val: 1234567891011125475893 },
+        Ray { val: 149519736606670 },
+        "Incorrect multiplication #8"
     );
 
     // wmul(ray, wad) -> ray
-    assert(wmul_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }) == Ray { val: RAY_ONE }, 'Incorrect multiplication #9');
+    assert_eq!(
+        wmul_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }), Ray { val: RAY_ONE }, "Incorrect multiplication #9"
+    );
 
     // wmul(wad, ray) -> ray
-    assert(wmul_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }) == Ray { val: RAY_ONE }, 'Incorrect multiplication #10');
+    assert_eq!(
+        wmul_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }), Ray { val: RAY_ONE }, "Incorrect multiplication #10"
+    );
 
     // rmul(ray, wad) -> wad
-    assert(rmul_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }) == Wad { val: WAD_ONE }, 'Incorrect multiplication #11');
+    assert_eq!(
+        rmul_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }), Wad { val: WAD_ONE }, "Incorrect multiplication #11"
+    );
 
     // rmul(wad, ray) -> wad
-    assert(rmul_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }) == Wad { val: WAD_ONE }, 'Incorrect multiplication #12');
+    assert_eq!(
+        rmul_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }), Wad { val: WAD_ONE }, "Incorrect multiplication #12"
+    );
 }
 
 #[test]
@@ -136,23 +149,23 @@ fn test_mul_eq() {
     let b = Wad { val: 3 };
 
     a1 *= b;
-    assert(a1 == a2 * b, 'Incorrect MulEq #1');
+    assert_eq!(a1, a2 * b, "Incorrect MulEq #1");
 }
 
 
 #[test]
 fn test_div() {
     // 2 / (1 / 2) = 4 (wad)
-    assert(Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 } == Wad { val: 4 * WAD_ONE }, 'Incorrect division #1');
+    assert_eq!(Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 }, Wad { val: 4 * WAD_ONE }, "Incorrect division #1");
 
     // 2 / (1 / 2) = 4 (ray)
-    assert(Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 } == Ray { val: 4 * RAY_ONE }, 'Incorrect division #2');
+    assert_eq!(Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 }, Ray { val: 4 * RAY_ONE }, "Incorrect division #2");
 
     // wdiv(ray, wad) -> ray
-    assert(wdiv_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }) == Ray { val: RAY_ONE }, 'Incorrect division #3');
+    assert_eq!(wdiv_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }), Ray { val: RAY_ONE }, "Incorrect division #3");
 
     // rdiv(wad, ray) -> wad
-    assert(rdiv_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }) == Wad { val: WAD_ONE }, 'Incorrect division #4');
+    assert_eq!(rdiv_wr(Wad { val: WAD_ONE }, Ray { val: RAY_ONE }), Wad { val: WAD_ONE }, "Incorrect division #4");
 }
 
 #[test]
@@ -162,7 +175,7 @@ fn test_div_eq() {
     let b = Wad { val: 3 };
 
     a1 /= b;
-    assert(a1 == a2 / b, 'Incorrect DivEq #1');
+    assert_eq!(a1, a2 / b, "Incorrect DivEq #1");
 }
 
 #[test]
@@ -172,11 +185,11 @@ fn test_div_of_0() {
     let w0 = Wad { val: 0 };
     let r0 = Ray { val: 0 };
 
-    assert(w0 / w == w0, 'w0 / w');
-    assert(r0 / r == r0, 'r0 / r');
-    assert(wdiv_rw(r0, w) == r0, 'wdiv_rw');
-    assert(rdiv_wr(w0, r) == w0, 'rdiv_wr');
-    assert(rdiv_ww(w0, w) == r0, 'rdiv_ww');
+    assert_eq!(w0 / w, w0, "w0 / w");
+    assert_eq!(r0 / r, r0, "r0 / r");
+    assert_eq!(wdiv_rw(r0, w), r0, "wdiv_rw");
+    assert_eq!(rdiv_wr(w0, r), w0, "rdiv_wr");
+    assert_eq!(rdiv_ww(w0, w), r0, "rdiv_ww");
 }
 
 #[test]
@@ -195,55 +208,55 @@ fn test_div_ray_fail() {
 fn test_conversions() {
     // Test conversion from Wad to Ray
     let a: Ray = Wad { val: WAD_ONE }.try_into().unwrap();
-    assert(a.val == RAY_ONE, 'Incorrect wad->ray conversion');
+    assert_eq!(a.val, RAY_ONE, "Incorrect wad->ray conversion");
 
     let a: Ray = Wad { val: MAX_CONVERTIBLE_WAD }.try_into().unwrap();
-    assert(a.val == MAX_CONVERTIBLE_WAD * DIFF, 'Incorrect wad->ray conversion');
+    assert_eq!(a.val, MAX_CONVERTIBLE_WAD * DIFF, "Incorrect wad->ray conversion");
 
     let a: Option::<Ray> = Wad { val: MAX_CONVERTIBLE_WAD + 1 }.try_into();
     assert(a.is_none(), 'Incorrect wad->ray conversion');
 
     // Test conversion from Ray to Wad
     let a: Wad = Ray { val: RAY_ONE }.into();
-    assert(a.val == WAD_ONE, 'Incorrect ray->wad conversion');
+    assert_eq!(a.val, WAD_ONE, "Incorrect ray->wad conversion");
 }
 
 #[test]
 fn test_conversions_from_primitive_types() {
-    assert(Wad { val: 1 } == 1_u8.into(), 'Wad u8');
-    assert(Wad { val: 1 } == 1_u16.into(), 'Wad u16');
-    assert(Wad { val: 1 } == 1_u32.into(), 'Wad u32');
-    assert(Wad { val: 1 } == 1_u64.into(), 'Wad u64');
-    assert(Wad { val: 1 } == 1_u128.into(), 'Wad u128');
+    assert_eq!(Wad { val: 1 }, 1_u8.into(), "Wad u8");
+    assert_eq!(Wad { val: 1 }, 1_u16.into(), "Wad u16");
+    assert_eq!(Wad { val: 1 }, 1_u32.into(), "Wad u32");
+    assert_eq!(Wad { val: 1 }, 1_u64.into(), "Wad u64");
+    assert_eq!(Wad { val: 1 }, 1_u128.into(), "Wad u128");
 
-    assert(Ray { val: 1 } == 1_u8.into(), 'Ray u8');
-    assert(Ray { val: 1 } == 1_u16.into(), 'Ray u16');
-    assert(Ray { val: 1 } == 1_u32.into(), 'Ray u32');
-    assert(Ray { val: 1 } == 1_u64.into(), 'Ray u64');
-    assert(Ray { val: 1 } == 1_u128.into(), 'Ray u128');
+    assert_eq!(Ray { val: 1 }, 1_u8.into(), "Ray u8");
+    assert_eq!(Ray { val: 1 }, 1_u16.into(), "Ray u16");
+    assert_eq!(Ray { val: 1 }, 1_u32.into(), "Ray u32");
+    assert_eq!(Ray { val: 1 }, 1_u64.into(), "Ray u64");
+    assert_eq!(Ray { val: 1 }, 1_u128.into(), "Ray u128");
 }
 
 #[test]
 fn test_bounded() {
     let max_u128 = 0xffffffffffffffffffffffffffffffff;
 
-    assert(BoundedWad::min() == Wad { val: 0 }, 'Wad min');
-    assert(BoundedWad::max() == Wad { val: max_u128 }, 'Wad max');
+    assert_eq!(BoundedWad::min(), Wad { val: 0 }, "Wad min");
+    assert_eq!(BoundedWad::max(), Wad { val: max_u128 }, "Wad max");
 
-    assert(BoundedRay::min() == Ray { val: 0 }, 'Ray min');
-    assert(BoundedRay::max() == Ray { val: max_u128 }, 'Ray max');
+    assert_eq!(BoundedRay::min(), Ray { val: 0 }, "Ray min");
+    assert_eq!(BoundedRay::max(), Ray { val: max_u128 }, "Ray max");
 }
 
 #[test]
 fn test_wadray_into_u256() {
     // Test WadIntoU256
-    assert(Wad { val: 5 }.into() == 5_u256, 'Incorrect Wad->u256 conversion')
+    assert_eq!(Wad { val: 5 }.into(), 5_u256, "Incorrect Wad->u256 conversion")
 }
 
 #[test]
 fn test_u256_try_into_wadray() {
     // Test U256TryIntoWad
-    assert(Wad { val: 5 } == 5_u256.try_into().unwrap(), 'Incorrect u256->Wad conversion');
+    assert_eq!(Wad { val: 5 }, 5_u256.try_into().unwrap(), "Incorrect u256->Wad conversion");
 }
 
 #[test]
@@ -295,7 +308,7 @@ fn test_comparisons2() {
 fn test_zeroable() {
     // Test zero
     let wad_zero = Wad { val: 0 };
-    assert(wad_zero.val == 0, 'Value should be 0 #1');
+    assert_eq!(wad_zero.val, 0, "Value should be 0 #1");
 
     // Test is_zero
     let wad_one = Wad { val: 1 };
@@ -307,7 +320,7 @@ fn test_zeroable() {
     assert(wad_one.is_non_zero(), 'Value should not be 0 #5');
 
     let ray_zero = Ray { val: 0 };
-    assert(ray_zero.val == 0, 'Value should be 0 #6');
+    assert_eq!(ray_zero.val, 0, "Value should be 0 #6");
 
     // Test is_zero
     let ray_one = Ray { val: 1 };
@@ -323,10 +336,10 @@ fn test_zeroable() {
 #[test]
 fn test_display_and_debug() {
     let w = Wad { val: 123 };
-    assert(format!("{}", w) == "123", 'Wad display');
-    assert(format!("{:?}", w) == "123", 'Wad debug');
+    assert_eq!(format!("{}", w), "123", "Wad display");
+    assert_eq!(format!("{:?}", w), "123", "Wad debug");
 
     let r = Ray { val: 456 };
-    assert(format!("{}", r) == "456", 'Ray display');
-    assert(format!("{:?}", r) == "456", 'Ray debug');
+    assert_eq!(format!("{}", r), "456", "Ray display");
+    assert_eq!(format!("{:?}", r), "456", "Ray debug");
 }

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -12,21 +12,21 @@ mod test_wadray_signed {
         let b = SignedWad { val: 100, sign: true };
         let c = SignedWad { val: 40, sign: true };
 
-        assert(a + b == SignedWadZeroable::zero(), 'a + b != 0');
-        assert(a - b == SignedWad { val: 200, sign: false }, 'a - b != 200');
-        assert(b - a == SignedWad { val: 200, sign: true }, 'b - a != -200');
-        assert(a + c == SignedWad { val: 60, sign: false }, 'a + c != 60');
-        assert(a - c == SignedWad { val: 140, sign: false }, 'a - c != 140');
+        assert_eq!(a + b, SignedWadZeroable::zero(), "a + b != 0");
+        assert_eq!(a - b, SignedWad { val: 200, sign: false }, "a - b != 200");
+        assert_eq!(b - a, SignedWad { val: 200, sign: true }, "b - a != -200");
+        assert_eq!(a + c, SignedWad { val: 60, sign: false }, "a + c != 60");
+        assert_eq!(a - c, SignedWad { val: 140, sign: false }, "a - c != 140");
 
         let a = SignedRay { val: 100, sign: false };
         let b = SignedRay { val: 100, sign: true };
         let c = SignedRay { val: 40, sign: true };
 
-        assert(a + b == SignedRayZeroable::zero(), 'a + b != 0');
-        assert(a - b == SignedRay { val: 200, sign: false }, 'a - b != 200');
-        assert(b - a == SignedRay { val: 200, sign: true }, 'b - a != -200');
-        assert(a + c == SignedRay { val: 60, sign: false }, 'a + c != 60');
-        assert(a - c == SignedRay { val: 140, sign: false }, 'a - c != 140');
+        assert_eq!(a + b, SignedRayZeroable::zero(), "a + b != 0");
+        assert_eq!(a - b, SignedRay { val: 200, sign: false }, "a - b != 200");
+        assert_eq!(b - a, SignedRay { val: 200, sign: true }, "b - a != -200");
+        assert_eq!(a + c, SignedRay { val: 60, sign: false }, "a + c != 60");
+        assert_eq!(a - c, SignedRay { val: 140, sign: false }, "a - c != 140");
     }
 
     #[test]
@@ -36,7 +36,7 @@ mod test_wadray_signed {
         let b = SignedWad { val: 3, sign: false };
 
         a1 += b;
-        assert(a1 == a2 + b, 'Incorrect AddEq #1');
+        assert_eq!(a1, a2 + b, "Incorrect AddEq #1");
     }
 
     #[test]
@@ -46,7 +46,7 @@ mod test_wadray_signed {
         let b = SignedWad { val: 3, sign: false };
 
         a1 -= b;
-        assert(a1 == a2 - b, 'Incorrect SubEq #1');
+        assert_eq!(a1, a2 - b, "Incorrect SubEq #1");
     }
 
     #[test]
@@ -57,14 +57,14 @@ mod test_wadray_signed {
         let d = SignedWad { val: WAD_ONE, sign: true }; // -1.0 ray
 
         // Test multiplication
-        assert((a * b) == SignedWad { val: 2 * WAD_ONE, sign: true }, 'a * b != -2.0');
-        assert((a * c) == SignedWad { val: 5 * WAD_ONE, sign: false }, 'a * c != 5.0');
-        assert((b * c) == SignedWad { val: 10 * WAD_ONE, sign: true }, 'b * c != -10.0');
+        assert_eq!((a * b), SignedWad { val: 2 * WAD_ONE, sign: true }, "a * b != -2.0");
+        assert_eq!((a * c), SignedWad { val: 5 * WAD_ONE, sign: false }, "a * c != 5.0");
+        assert_eq!((b * c), SignedWad { val: 10 * WAD_ONE, sign: true }, "b * c != -10.0");
 
         // Test division
-        assert((c / a) == SignedWad { val: 5 * WAD_ONE, sign: false }, 'c / a != 5.0');
-        assert((a / d) == SignedWad { val: 1 * WAD_ONE, sign: true }, 'a / d != -1.0');
-        assert((b / d) == SignedWad { val: 2 * WAD_ONE, sign: false }, 'b / d != 2.0');
+        assert_eq!((c / a), SignedWad { val: 5 * WAD_ONE, sign: false }, "c / a != 5.0");
+        assert_eq!((a / d), SignedWad { val: 1 * WAD_ONE, sign: true }, "a / d != -1.0");
+        assert_eq!((b / d), SignedWad { val: 2 * WAD_ONE, sign: false }, "b / d != 2.0");
 
         let a = SignedRay { val: RAY_ONE, sign: false }; // 1.0 ray
         let b = SignedRay { val: 2 * RAY_ONE, sign: true }; // -2.0 ray
@@ -72,14 +72,14 @@ mod test_wadray_signed {
         let d = SignedRay { val: RAY_ONE, sign: true }; // -1.0 ray
 
         // Test multiplication
-        assert((a * b) == SignedRay { val: 2 * RAY_ONE, sign: true }, 'a * b != -2.0');
-        assert((a * c) == SignedRay { val: 5 * RAY_ONE, sign: false }, 'a * c != 5.0');
-        assert((b * c) == SignedRay { val: 10 * RAY_ONE, sign: true }, 'b * c != -10.0');
+        assert_eq!((a * b), SignedRay { val: 2 * RAY_ONE, sign: true }, "a * b != -2.0");
+        assert_eq!((a * c), SignedRay { val: 5 * RAY_ONE, sign: false }, "a * c != 5.0");
+        assert_eq!((b * c), SignedRay { val: 10 * RAY_ONE, sign: true }, "b * c != -10.0");
 
         // Test division
-        assert((c / a) == SignedRay { val: 5 * RAY_ONE, sign: false }, 'c / a != 5.0');
-        assert((a / d) == SignedRay { val: 1 * RAY_ONE, sign: true }, 'a / d != -1.0');
-        assert((b / d) == SignedRay { val: 2 * RAY_ONE, sign: false }, 'b / d != 2.0');
+        assert_eq!((c / a), SignedRay { val: 5 * RAY_ONE, sign: false }, "c / a != 5.0");
+        assert_eq!((a / d), SignedRay { val: 1 * RAY_ONE, sign: true }, "a / d != -1.0");
+        assert_eq!((b / d), SignedRay { val: 2 * RAY_ONE, sign: false }, "b / d != 2.0");
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod test_wadray_signed {
         let b = SignedWad { val: 3, sign: false };
 
         a1 *= b;
-        assert(a1 == a2 * b, 'Incorrect MulEq #1');
+        assert_eq!(a1, a2 * b, "Incorrect MulEq #1");
     }
 
     #[test]
@@ -99,7 +99,7 @@ mod test_wadray_signed {
         let b = SignedWad { val: 3, sign: false };
 
         a1 /= b;
-        assert(a1 == a2 / b, 'Incorrect DivEq #1');
+        assert_eq!(a1, a2 / b, "Incorrect DivEq #1");
     }
 
     #[test]
@@ -189,11 +189,11 @@ mod test_wadray_signed {
     fn test_bounded() {
         let max_u128 = 0xffffffffffffffffffffffffffffffff;
 
-        assert(BoundedSignedWad::min() == SignedWad { val: max_u128, sign: true }, 'SignedWad min');
-        assert(BoundedSignedWad::max() == SignedWad { val: max_u128, sign: false }, 'SignedWad max');
+        assert_eq!(BoundedSignedWad::min(), SignedWad { val: max_u128, sign: true }, "SignedWad min");
+        assert_eq!(BoundedSignedWad::max(), SignedWad { val: max_u128, sign: false }, "SignedWad max");
 
-        assert(BoundedSignedRay::min() == SignedRay { val: max_u128, sign: true }, 'SignedRay min');
-        assert(BoundedSignedRay::max() == SignedRay { val: max_u128, sign: false }, 'SignedRay max');
+        assert_eq!(BoundedSignedRay::min(), SignedRay { val: max_u128, sign: true }, "SignedRay min");
+        assert_eq!(BoundedSignedRay::max(), SignedRay { val: max_u128, sign: false }, "SignedRay max");
     }
 
     #[test]
@@ -201,20 +201,20 @@ mod test_wadray_signed {
         // Test U128IntoSignedWad
         let a: u128 = 100;
         let a_signed: SignedWad = a.into();
-        assert(a_signed.val == a, 'U128IntoSignedWad val fail');
+        assert_eq!(a_signed.val, a, "U128IntoSignedWad val fail");
         assert(!a_signed.sign, 'U128IntoSignedWad sign fail');
 
         // Test WadIntoSignedWad
         let b = Wad { val: 200 };
         let b_signed: SignedWad = b.into();
-        assert(b_signed.val == b.val, 'WadIntoSignedWad val fail');
+        assert_eq!(b_signed.val, b.val, "WadIntoSignedWad val fail");
         assert(!b_signed.sign, 'WadIntoSignedWad sign fail');
 
         // Test SignedWadTryIntoWad
         let d = SignedWad { val: 400, sign: false };
         let d_wad: Option<Wad> = d.try_into();
         assert(d_wad.is_some(), 'SignedWadTryIntoWad pos fail');
-        assert(d_wad.unwrap().val == d.val, 'SignedWadTryIntoWad val fail');
+        assert_eq!(d_wad.unwrap().val, d.val, "SignedWadTryIntoWad val fail");
 
         let e = SignedWad { val: 500, sign: true };
         let e_wad: Option<Wad> = e.try_into();
@@ -223,26 +223,26 @@ mod test_wadray_signed {
         // Test U128IntoSignedRay
         let a: u128 = 100;
         let a_signed: SignedRay = a.into();
-        assert(a_signed.val == a, 'U128IntoSignedRay val fail');
+        assert_eq!(a_signed.val, a, "U128IntoSignedRay val fail");
         assert(!a_signed.sign, 'U128IntoSignedRay sign fail');
 
         // Test RayIntoSignedRay
         let b = Ray { val: 200 };
         let b_signed: SignedRay = b.into();
-        assert(b_signed.val == b.val, 'RayIntoSignedRay val fail');
+        assert_eq!(b_signed.val, b.val, "RayIntoSignedRay val fail");
         assert(!b_signed.sign, 'RayIntoSignedRay sign fail');
 
         // Test WadIntoSignedRay
         let c = Wad { val: 300 * WAD_ONE };
         let c_signed: SignedRay = c.into();
-        assert(c_signed.val == c.val * DIFF, 'WadIntoSignedRay val fail');
+        assert_eq!(c_signed.val, c.val * DIFF, "WadIntoSignedRay val fail");
         assert(!c_signed.sign, 'WadIntoSignedRay sign fail');
 
         // Test SignedRayTryIntoRay
         let d = SignedRay { val: 400, sign: false };
         let d_ray: Option<Ray> = d.try_into();
         assert(d_ray.is_some(), 'SignedRayTryIntoRay pos fail');
-        assert(d_ray.unwrap().val == d.val, 'SignedRayTryIntoRay val fail');
+        assert_eq!(d_ray.unwrap().val, d.val, "SignedRayTryIntoRay val fail");
 
         let e = SignedRay { val: 500, sign: true };
         let e_ray: Option<Ray> = e.try_into();
@@ -253,7 +253,7 @@ mod test_wadray_signed {
     fn test_zeroable_oneable() {
         // Test SignedWadZeroable
         let zero = SignedWadZeroable::zero();
-        assert(zero.val == 0, 'Zeroable zero fail');
+        assert_eq!(zero.val, 0, "Zeroable zero fail");
         assert(!zero.sign, 'Zeroable zero sign fail');
         assert(zero.is_zero(), 'Zeroable is_zero fail');
         assert(!zero.is_non_zero(), 'Zeroable is_non_zero fail');
@@ -264,7 +264,7 @@ mod test_wadray_signed {
 
         // Test SignedWadOneable
         let one = SignedWadOneable::one();
-        assert(one.val == WAD_ONE, 'Oneable one fail');
+        assert_eq!(one.val, WAD_ONE, "Oneable one fail");
         assert(!one.sign, 'Oneable one sign fail');
         assert(one.is_one(), 'Oneable is_one fail');
         assert(!one.is_non_one(), 'Oneable is_non_one fail');
@@ -279,7 +279,7 @@ mod test_wadray_signed {
 
         // Test SignedRayZeroable
         let zero = SignedRayZeroable::zero();
-        assert(zero.val == 0, 'Zeroable zero fail');
+        assert_eq!(zero.val, 0, "Zeroable zero fail");
         assert(!zero.sign, 'Zeroable zero sign fail');
         assert(zero.is_zero(), 'Zeroable is_zero fail');
         assert(!zero.is_non_zero(), 'Zeroable is_non_zero fail');
@@ -290,7 +290,7 @@ mod test_wadray_signed {
 
         // Test SignedRayOneable
         let one = SignedRayOneable::one();
-        assert(one.val == RAY_ONE, 'Oneable one fail');
+        assert_eq!(one.val, RAY_ONE, "Oneable one fail");
         assert(!one.sign, 'Oneable one sign fail');
         assert(one.is_one(), 'Oneable is_one fail');
         assert(!one.is_non_one(), 'Oneable is_non_one fail');
@@ -330,7 +330,7 @@ mod test_wadray_signed {
         let pos_zero = SignedWad { val: 0, sign: false };
         let neg_zero = SignedWad { val: 0, sign: true };
 
-        assert(pos_zero == neg_zero, 'Zero eq');
+        assert_eq!(pos_zero, neg_zero, "Zero eq");
         assert(!(pos_zero != neg_zero), 'Zero neq');
         assert(pos_zero >= neg_zero, 'Zero ge');
         assert(pos_zero <= neg_zero, 'Zero le');
@@ -340,7 +340,7 @@ mod test_wadray_signed {
         let pos_zero = SignedRay { val: 0, sign: false };
         let neg_zero = SignedRay { val: 0, sign: true };
 
-        assert(pos_zero == neg_zero, 'Zero eq');
+        assert_eq!(pos_zero, neg_zero, "Zero eq");
         assert(!(pos_zero != neg_zero), 'Zero neq');
         assert(pos_zero >= neg_zero, 'Zero ge');
         assert(pos_zero <= neg_zero, 'Zero le');
@@ -351,11 +351,11 @@ mod test_wadray_signed {
     #[test]
     fn test_display_and_debug() {
         let w = SignedWad { val: 123, sign: true };
-        assert(format!("{}", w) == "-123", 'SignedWad display');
-        assert(format!("{:?}", w) == "-123", 'SignedWad debug');
+        assert_eq!(format!("{}", w), "-123", "SignedWad display");
+        assert_eq!(format!("{:?}", w), "-123", "SignedWad debug");
 
         let r = SignedRay { val: 456, sign: false };
-        assert(format!("{}", r) == "456", 'SignedRay display');
-        assert(format!("{:?}", r) == "456", 'SignedRay debug');
+        assert_eq!(format!("{}", r), "456", "SignedRay display");
+        assert_eq!(format!("{:?}", r), "456", "SignedRay debug");
     }
 }

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -347,4 +347,15 @@ mod test_wadray_signed {
         assert(!(pos_zero > neg_zero), 'Zero gt');
         assert(!(pos_zero < neg_zero), 'Zero lt');
     }
+
+    #[test]
+    fn test_display_and_debug() {
+        let w = SignedWad { val: 123, sign: true };
+        assert(format!("{}", w) == "-123", 'SignedWad display');
+        assert(format!("{:?}", w) == "-123", 'SignedWad debug');
+
+        let r = SignedRay { val: 456, sign: false };
+        assert(format!("{}", r) == "456", 'SignedRay display');
+        assert(format!("{:?}", r) == "456", 'SignedRay debug');
+    }
 }

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,3 +1,4 @@
+use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
 use integer::BoundedInt;
 use math::Oneable;
 
@@ -487,5 +488,30 @@ impl WadPrintImpl of debug::PrintTrait<Wad> {
 impl RayPrintImpl of debug::PrintTrait<Ray> {
     fn print(self: Ray) {
         self.val.print();
+    }
+}
+
+// Display and Debug
+impl DisplayWad of Display<Wad> {
+    fn fmt(self: @Wad, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self.val, ref f)
+    }
+}
+
+impl DisplayRay of Display<Ray> {
+    fn fmt(self: @Ray, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self.val, ref f)
+    }
+}
+
+impl DebugWad of Debug<Wad> {
+    fn fmt(self: @Wad, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self, ref f)
+    }
+}
+
+impl DebugRay of Debug<Ray> {
+    fn fmt(self: @Ray, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self, ref f)
     }
 }

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,5 +1,4 @@
 use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
-use debug::PrintTrait;
 use integer::BoundedInt;
 use math::Oneable;
 use wadray::wadray::{DIFF, Ray, RAY_ONE, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_ONE};

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,3 +1,4 @@
+use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
 use debug::PrintTrait;
 use integer::BoundedInt;
 use math::Oneable;
@@ -485,5 +486,39 @@ impl SignedRaySigned of Signed<SignedRay> {
 
     fn is_positive(self: SignedRay) -> bool {
         self.val > 0 && !self.sign
+    }
+}
+
+
+// Display and Debug
+impl DisplaySignedWad of Display<SignedWad> {
+    fn fmt(self: @SignedWad, ref f: Formatter) -> Result<(), Error> {
+        if *self.sign {
+            write!(f, "-");
+        }
+
+        Display::fmt(self.val, ref f)
+    }
+}
+
+impl DisplaySignedRay of Display<SignedRay> {
+    fn fmt(self: @SignedRay, ref f: Formatter) -> Result<(), Error> {
+        if *self.sign {
+            write!(f, "-");
+        }
+
+        Display::fmt(self.val, ref f)
+    }
+}
+
+impl DebugSignedWad of Debug<SignedWad> {
+    fn fmt(self: @SignedWad, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self, ref f)
+    }
+}
+
+impl DebugSignedRay of Debug<SignedRay> {
+    fn fmt(self: @SignedRay, ref f: Formatter) -> Result<(), Error> {
+        Display::fmt(self, ref f)
     }
 }


### PR DESCRIPTION
This PR implements Display and Debug traits.

In addition, it also bumps Cairo to `2.4.0` and uses the `assert_eq!` macro.