### PR TITLE
test: improve wadray test coverage

### DIFF
--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -369,7 +369,7 @@ fn test_oneable() {
     assert_eq!(wad_one.val, 1, "Value should be 1 #1");
 
     // Test is_one
-    let wad_one = Wad { val: 1 };
+    let wad_zero: Wad = Zeroable::zero();
     assert(wad_one.is_one(), 'Value should be 1 #2');
     assert(!wad_zero.is_one(), 'Value should not be 1 #3');
 
@@ -382,7 +382,7 @@ fn test_oneable() {
     assert_eq!(ray_one.val, 1, "Value should be 1 #6");
 
     // Test is_one
-    let ray_one = Ray { val: 1 };
+    let ray_zero: Ray = Zeroable::zero();
     assert(ray_one.is_one(), 'Value should be 1 #7');
     assert(!ray_zero.is_one(), 'Value should not be 1 #8');
 

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -2,7 +2,6 @@ use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
     WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
 };
-use math::Oneable;
 
 #[test]
 fn test_add() {

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,3 +1,4 @@
+use math::Oneable;
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
     WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
@@ -39,14 +40,14 @@ fn test_add_eq() {
     let b = Wad { val: 3 };
 
     a1 += b;
-    assert_eq!(a1, a2 + b, 'Incorrect AddEq #1');
+    assert_eq!(a1, a2 + b, "Incorrect AddEq #1");
 
     let mut a1 = Ray { val: 5 };
     let a2 = Ray { val: 5 };
     let b = Ray { val: 3 };
 
     a1 += b;
-    assert_eq!(a1, a2 + b, 'Incorrect AddEq #2');
+    assert_eq!(a1, a2 + b, "Incorrect AddEq #2");
 }
 
 
@@ -163,14 +164,14 @@ fn test_mul_eq() {
     let b = Wad { val: 3 };
 
     a1 *= b;
-    assert_eq!(a1, a2 * b, 'Incorrect MulEq #1');
+    assert_eq!(a1, a2 * b, "Incorrect MulEq #1");
 
     let mut a1 = Ray { val: 5 };
     let a2 = Ray { val: 5 };
     let b = Ray { val: 3 };
 
     a1 *= b;
-    assert_eq!(a1, a2 * b, 'Incorrect MulEq #2');
+    assert_eq!(a1, a2 * b, "Incorrect MulEq #2");
 }
 
 
@@ -196,14 +197,14 @@ fn test_div_eq() {
     let b = Wad { val: 3 };
 
     a1 /= b;
-    assert_eq!(a1, a2 / b, 'Incorrect DivEq #1');
+    assert_eq!(a1, a2 / b, "Incorrect DivEq #1");
 
     let mut a1 = Ray { val: 15 };
     let a2 = Ray { val: 15 };
     let b = Ray { val: 3 };
 
     a1 /= b;
-    assert_eq!(a1, a2 / b, 'Incorrect DivEq #2');
+    assert_eq!(a1, a2 / b, "Incorrect DivEq #2");
 }
 
 #[test]
@@ -336,7 +337,7 @@ fn test_comparisons2() {
 fn test_zeroable() {
     // Test zero
     let wad_zero: Wad = Zeroable::zero();
-    assert_eq!(wad_zero.val, 0, 'Value should be 0 #1');
+    assert_eq!(wad_zero.val, 0, "Value should be 0 #1");
 
     // Test is_zero
     let wad_one = Wad { val: 1 };
@@ -349,7 +350,7 @@ fn test_zeroable() {
 
     // Test zero
     let ray_zero: Ray = Zeroable::zero();
-    assert_eq!(ray_zero.val, 0, 'Value should be 0 #6');
+    assert_eq!(ray_zero.val, 0, "Value should be 0 #6");
 
     // Test is_zero
     let ray_one = Ray { val: 1 };
@@ -365,7 +366,7 @@ fn test_zeroable() {
 fn test_oneable() {
     // Test one
     let wad_one: Wad = Oneable::one();
-    assert_eq!(wad_one.val, 1, 'Value should be 1 #1');
+    assert_eq!(wad_one.val, 1, "Value should be 1 #1");
 
     // Test is_one
     let wad_one = Wad { val: 1 };
@@ -378,7 +379,7 @@ fn test_oneable() {
 
     // Test one
     let ray_one: Ray = Oneable::one();
-    assert_eq!(ray_one.val, 1, 'Value should be 1 #6');
+    assert_eq!(ray_one.val, 1, "Value should be 1 #6");
 
     // Test is_one
     let ray_one = Ray { val: 1 };

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -87,14 +87,14 @@ fn test_sub_eq() {
     let b = Wad { val: 3 };
 
     a1 -= b;
-    assert_eq!(a1, a2 - b, 'Incorrect SubEq #1');
+    assert_eq!(a1, a2 - b, "Incorrect SubEq #1");
 
     let mut a1 = Ray { val: 5 };
     let a2 = Ray { val: 5 };
     let b = Ray { val: 3 };
 
     a1 -= b;
-    assert_eq!(a1, a2 - b, 'Incorrect SubEq #2');
+    assert_eq!(a1, a2 - b, "Incorrect SubEq #2");
 }
 
 

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -97,8 +97,7 @@ fn test_sub_eq() {
 #[test]
 fn test_mul() {
     // 0 * 69 = 0
-    let lhs = Wad { val: 0 } * Wad { val: 69 };
-    assert(lhs == Wad { val: 0 }, 'Incorrect Multiplication # 1');
+    assert(Wad { val: 0 } * Wad { val: 69 } == Wad { val: 0 }, 'Incorrect Multiplication # 1');
 
     // 1 * 1 = 0 (truncated)
     assert(
@@ -116,8 +115,7 @@ fn test_mul() {
     );
 
     // 0 * 69 = 0
-    let lhs = Ray { val: 0 } * Ray { val: 69 };
-    assert(lhs == Ray { val: 0 }, 'Incorrect Multiplication #5');
+    assert(Ray { val: 0 } * Ray { val: 69 } == Ray { val: 0 }, 'Incorrect Multiplication #5');
 
     // 1 * 1 = 0 (truncated)
     assert(
@@ -167,12 +165,10 @@ fn test_mul_eq() {
 #[test]
 fn test_div() {
     // 2 / (1 / 2) = 4 (wad)
-    let lhs = Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 };
-    assert(lhs == Wad { val: 4 * WAD_ONE }, 'Incorrect division #1');
+    assert(Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 } == Wad { val: 4 * WAD_ONE }, 'Incorrect division #1');
 
     // 2 / (1 / 2) = 4 (ray)
-    let lhs = Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 };
-    assert(lhs == Ray { val: 4 * RAY_ONE }, 'Incorrect division #2');
+    assert(Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 } == Ray { val: 4 * RAY_ONE }, 'Incorrect division #2');
 
     // wdiv(ray, wad) -> ray
     assert(wdiv_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }) == Ray { val: RAY_ONE }, 'Incorrect division #3');

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -390,3 +390,14 @@ fn test_oneable() {
     assert(!ray_one.is_non_one(), 'Value should be 1 #9');
     assert(ray_zero.is_non_one(), 'Value should not be 1 #10');
 }
+
+#[test]
+fn test_display_and_debug() {
+    let w = Wad { val: 123 };
+    assert_eq!(format!("{}", w), "123", "Wad display");
+    assert_eq!(format!("{:?}", w), "123", "Wad debug");
+
+    let r = Ray { val: 456 };
+    assert_eq!(format!("{}", r), "456", "Ray display");
+    assert_eq!(format!("{:?}", r), "456", "Ray debug");
+}

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -2,6 +2,7 @@ use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
     WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
 };
+use math::Oneable;
 
 #[test]
 fn test_add() {
@@ -38,6 +39,13 @@ fn test_add_eq() {
 
     a1 += b;
     assert(a1 == a2 + b, 'Incorrect AddEq #1');
+
+    let mut a1 = Ray { val: 5 };
+    let a2 = Ray { val: 5 };
+    let b = Ray { val: 3 };
+
+    a1 += b;
+    assert(a1 == a2 + b, 'Incorrect AddEq #2');
 }
 
 
@@ -76,13 +84,21 @@ fn test_sub_eq() {
 
     a1 -= b;
     assert(a1 == a2 - b, 'Incorrect SubEq #1');
+
+    let mut a1 = Ray { val: 5 };
+    let a2 = Ray { val: 5 };
+    let b = Ray { val: 3 };
+
+    a1 -= b;
+    assert(a1 == a2 - b, 'Incorrect SubEq #2');
 }
 
 
 #[test]
 fn test_mul() {
     // 0 * 69 = 0
-    assert(Wad { val: 0 } * Wad { val: 69 } == Wad { val: 0 }, 'Incorrect Multiplication # 1');
+    let lhs = Wad { val: 0 } * Wad { val: 69 };
+    assert(lhs == Wad { val: 0 }, 'Incorrect Multiplication # 1');
 
     // 1 * 1 = 0 (truncated)
     assert(
@@ -100,7 +116,8 @@ fn test_mul() {
     );
 
     // 0 * 69 = 0
-    assert(Ray { val: 0 } * Ray { val: 69 } == Ray { val: 0 }, 'Incorrect Multiplication #5');
+    let lhs = Ray { val: 0 } * Ray { val: 69 };
+    assert(lhs == Ray { val: 0 }, 'Incorrect Multiplication #5');
 
     // 1 * 1 = 0 (truncated)
     assert(
@@ -137,16 +154,25 @@ fn test_mul_eq() {
 
     a1 *= b;
     assert(a1 == a2 * b, 'Incorrect MulEq #1');
+
+    let mut a1 = Ray { val: 5 };
+    let a2 = Ray { val: 5 };
+    let b = Ray { val: 3 };
+
+    a1 *= b;
+    assert(a1 == a2 * b, 'Incorrect MulEq #2');
 }
 
 
 #[test]
 fn test_div() {
     // 2 / (1 / 2) = 4 (wad)
-    assert(Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 } == Wad { val: 4 * WAD_ONE }, 'Incorrect division #1');
+    let lhs = Wad { val: 2 * WAD_ONE } / Wad { val: WAD_ONE / 2 };
+    assert(lhs == Wad { val: 4 * WAD_ONE }, 'Incorrect division #1');
 
     // 2 / (1 / 2) = 4 (ray)
-    assert(Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 } == Ray { val: 4 * RAY_ONE }, 'Incorrect division #2');
+    let lhs = Ray { val: 2 * RAY_ONE } / Ray { val: RAY_ONE / 2 };
+    assert(lhs == Ray { val: 4 * RAY_ONE }, 'Incorrect division #2');
 
     // wdiv(ray, wad) -> ray
     assert(wdiv_rw(Ray { val: RAY_ONE }, Wad { val: WAD_ONE }) == Ray { val: RAY_ONE }, 'Incorrect division #3');
@@ -163,6 +189,13 @@ fn test_div_eq() {
 
     a1 /= b;
     assert(a1 == a2 / b, 'Incorrect DivEq #1');
+
+    let mut a1 = Ray { val: 15 };
+    let a2 = Ray { val: 15 };
+    let b = Ray { val: 3 };
+
+    a1 /= b;
+    assert(a1 == a2 / b, 'Incorrect DivEq #2');
 }
 
 #[test]
@@ -237,7 +270,10 @@ fn test_bounded() {
 #[test]
 fn test_wadray_into_u256() {
     // Test WadIntoU256
-    assert(Wad { val: 5 }.into() == 5_u256, 'Incorrect Wad->u256 conversion')
+    assert(Wad { val: 5 }.into() == 5_u256, 'Incorrect Wad->u256 conversion');
+
+    // Test RayIntoU256
+    assert(Ray { val: 5 }.into() == 5_u256, 'Incorrect Ray->u256 conversion');
 }
 
 #[test]
@@ -294,7 +330,7 @@ fn test_comparisons2() {
 #[test]
 fn test_zeroable() {
     // Test zero
-    let wad_zero = Wad { val: 0 };
+    let wad_zero: Wad = Zeroable::zero();
     assert(wad_zero.val == 0, 'Value should be 0 #1');
 
     // Test is_zero
@@ -306,7 +342,8 @@ fn test_zeroable() {
     assert(!wad_zero.is_non_zero(), 'Value should be 0 #4');
     assert(wad_one.is_non_zero(), 'Value should not be 0 #5');
 
-    let ray_zero = Ray { val: 0 };
+    // Test zero
+    let ray_zero: Ray = Zeroable::zero();
     assert(ray_zero.val == 0, 'Value should be 0 #6');
 
     // Test is_zero
@@ -317,4 +354,33 @@ fn test_zeroable() {
     // Test is_non_zero
     assert(!ray_zero.is_non_zero(), 'Value should be 0 #9');
     assert(ray_one.is_non_zero(), 'Value should not be 0 #10');
+}
+
+#[test]
+fn test_oneable() {
+    // Test one
+    let wad_one: Wad = Oneable::one();
+    assert(wad_one.val == 1, 'Value should be 1 #1');
+
+    // Test is_one
+    let wad_one = Wad { val: 1 };
+    assert(wad_one.is_one(), 'Value should be 1 #2');
+    assert(!wad_one.is_one(), 'Value should not be 1 #3');
+
+    // Test is_non_one
+    assert(!wad_one.is_non_one(), 'Value should be 1 #4');
+    assert(wad_one.is_non_one(), 'Value should not be 1 #5');
+
+    // Test one
+    let ray_one: Ray = Oneable::one();
+    assert(ray_one.val == 1, 'Value should be 1 #6');
+
+    // Test is_one
+    let ray_one = Ray { val: 1 };
+    assert(ray_one.is_one(), 'Value should be 1 #7');
+    assert(!ray_one.is_one(), 'Value should not be 1 #8');
+
+    // Test is_non_one
+    assert(!ray_one.is_non_one(), 'Value should be 1 #9');
+    assert(ray_one.is_non_one(), 'Value should not be 1 #10');
 }

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -366,7 +366,7 @@ fn test_zeroable() {
 fn test_oneable() {
     // Test one
     let wad_one: Wad = Oneable::one();
-    assert_eq!(wad_one.val, 1, "Value should be 1 #1");
+    assert_eq!(wad_one.val, 1000000000000000000, "Value should be WAD_ONE #1");
 
     // Test is_one
     let wad_zero: Wad = Zeroable::zero();
@@ -379,7 +379,7 @@ fn test_oneable() {
 
     // Test one
     let ray_one: Ray = Oneable::one();
-    assert_eq!(ray_one.val, 1, "Value should be 1 #6");
+    assert_eq!(ray_one.val, 1000000000000000000000000000, "Value should be RAY_ONE #6");
 
     // Test is_one
     let ray_zero: Ray = Zeroable::zero();


### PR DESCRIPTION
Adds coverage for the following functions that has been missing so far:
```cairo
WadZeroable::zero()
RayZeroable::zero()
RayIntoU256
RayAddEq::add_eq
RaySubEq::sub_eq
RayMulEq::mul_eq
RayDivEq::div_eq
WadZeroable::zero
RayZeroable::zero
WadOnable::one
WadOnable::is_one
WadOnable::is_non_one
RayOnable::one
RayOnable::is_one
RayOnable::is_non_one
```