### PR TITLE
chore: refactor xor

### DIFF
--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -53,7 +53,7 @@ fn _felt_abs(a: felt252) -> felt252 {
 
 // Returns the sign of the product in signed multiplication (or quotient in division)
 fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
-    (!lhs_sign && rhs_sign) || (lhs_sign && !rhs_sign)
+    lhs_sign ^ rhs_sign
 }
 
 //


### PR DESCRIPTION
This PR refactors the use of XOR when determining the sign for the result of a multiplication or division of signed wadray.