### PR TITLE
fix: clarify conversion of Wad to SignedRay

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -8,7 +8,7 @@ use wadray::{
 };
 use wadray_signed::{
     BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOneable, SignedRayZeroable, SignedWad,
-    SignedWadOneable, SignedWadZeroable,
+    SignedWadOneable, SignedWadZeroable, wad_to_signed_ray
 };
 #[cfg(test)]
 mod tests {

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -444,8 +444,8 @@ mod test_wadray_signed {
     fn test_conversions() {
         let c = Wad { val: 300 * WAD_ONE };
         let c_signed: SignedRay = wad_to_signed_ray(c);
-        assert_eq!(c_signed.val, c.val * DIFF, "WadIntoSignedRay val fail");
-        assert(!c_signed.sign, 'WadIntoSignedRay sign fail');
+        assert_eq!(c_signed.val, c.val * DIFF, "wad_to_signed_ray val fail");
+        assert(!c_signed.sign, 'wad_to_signed_ray sign fail');
     }
 
     #[test]

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -3,7 +3,7 @@ mod test_wadray_signed {
     use math::Oneable;
     use wadray::{
         BoundedSignedWad, BoundedSignedRay, DIFF, Ray, RAY_ONE, Signed, SignedRay, SignedRayOneable, SignedRayZeroable,
-        SignedWad, SignedWadOneable, SignedWadZeroable, Wad, WAD_ONE
+        SignedWad, SignedWadOneable, SignedWadZeroable, Wad, WAD_ONE, wad_to_signed_ray
     };
 
     #[test]
@@ -330,12 +330,6 @@ mod test_wadray_signed {
         assert_eq!(b_signed.val, b.val, "RayIntoSignedRay val fail");
         assert(!b_signed.sign, 'RayIntoSignedRay sign fail');
 
-        // Test WadIntoSignedRay
-        let c = Wad { val: 300 * WAD_ONE };
-        let c_signed: SignedRay = c.into();
-        assert_eq!(c_signed.val, c.val * DIFF, "WadIntoSignedRay val fail");
-        assert(!c_signed.sign, 'WadIntoSignedRay sign fail');
-
         // Test SignedRayTryIntoRay
         let d = SignedRay { val: 400, sign: false };
         let d_ray: Option<Ray> = d.try_into();
@@ -444,6 +438,14 @@ mod test_wadray_signed {
         assert(pos_zero <= neg_zero, 'Zero le');
         assert(!(pos_zero > neg_zero), 'Zero gt');
         assert(!(pos_zero < neg_zero), 'Zero lt');
+    }
+
+    #[test]
+    fn test_conversions() {
+        let c = Wad { val: 300 * WAD_ONE };
+        let c_signed: SignedRay = wad_to_signed_ray(c);
+        assert_eq!(c_signed.val, c.val * DIFF, "WadIntoSignedRay val fail");
+        assert(!c_signed.sign, 'WadIntoSignedRay sign fail');
     }
 
     #[test]

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -18,6 +18,11 @@ struct SignedRay {
     sign: bool
 }
 
+// External helpers
+fn wad_to_signed_ray(a: Wad) -> SignedRay {
+    SignedRay { val: a.val * DIFF, sign: false }
+}
+
 //
 // Internal helpers
 //
@@ -220,12 +225,6 @@ impl SignedRayIntoFelt252 of Into<SignedRay, felt252> {
 impl WadIntoSignedWad of Into<Wad, SignedWad> {
     fn into(self: Wad) -> SignedWad {
         SignedWad { val: self.val, sign: false }
-    }
-}
-
-impl WadIntoSignedRay of Into<Wad, SignedRay> {
-    fn into(self: Wad) -> SignedRay {
-        SignedRay { val: self.val * DIFF, sign: false }
     }
 }
 

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -58,7 +58,7 @@ fn _felt_abs(a: felt252) -> felt252 {
 
 // Returns the sign of the product in signed multiplication (or quotient in division)
 fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
-    lhs_sign ^ rhs_sign
+    (!lhs_sign && rhs_sign) || (lhs_sign && !rhs_sign)
 }
 
 //

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -53,7 +53,7 @@ fn _felt_abs(a: felt252) -> felt252 {
 
 // Returns the sign of the product in signed multiplication (or quotient in division)
 fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
-    (!lhs_sign && rhs_sign) || (lhs_sign && !rhs_sign)
+    lhs_sign ^ rhs_sign
 }
 
 //


### PR DESCRIPTION
This PR replaces the implementation of `Into<Wad, SignedRay>` with a helper function `wad_to_signed_ray` to better reflect the semantics that the wad value is being scaled by `10**9`, whereas the `Into` trait typically suggests that the underlying value is unmodified.