### PR TITLE
feat: StorePacking for Signed types

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "snforge_std"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.13.1#e1412ed040d10e66be0fd84115f72a667b57a116"
+version = "0.14.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.14.0#e8cbecee4e31ed428c76d5173eaa90c8df796fe3"
 
 [[package]]
 name = "wadray"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/lindy-labs/wadray"
 license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
+[dependencies]
+starknet = ">= 2.4"
+
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.14.0" }
 

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -1,6 +1,7 @@
 mod test_wadray_signed {
-    use debug::PrintTrait;
+    use integer::BoundedInt;
     use math::Oneable;
+    use starknet::StorePacking;
     use wadray::{
         BoundedSignedWad, BoundedSignedRay, DIFF, Ray, RAY_ONE, Signed, SignedRay, SignedRayOneable, SignedRayZeroable,
         SignedWad, SignedWadOneable, SignedWadZeroable, Wad, WAD_ONE, wad_to_signed_ray
@@ -467,5 +468,40 @@ mod test_wadray_signed {
         let r = SignedRay { val: 456, sign: false };
         assert_eq!(format!("{}", r), "456", "SignedRay display");
         assert_eq!(format!("{:?}", r), "456", "SignedRay debug");
+    }
+
+    #[test]
+    fn test_store_packing() {
+        let w = SignedWad { val: 123, sign: true };
+        let ww: SignedWad = StorePacking::unpack(StorePacking::pack(w));
+        assert_eq!(w, ww, "SignedWad packing 1");
+
+        let w = SignedWad { val: 123, sign: false };
+        let ww: SignedWad = StorePacking::unpack(StorePacking::pack(w));
+        assert_eq!(w, ww, "SignedWad packing 2");
+
+        let w = SignedWad { val: BoundedInt::max(), sign: true };
+        let ww: SignedWad = StorePacking::unpack(StorePacking::pack(w));
+        assert_eq!(w, ww, "SignedWad packing 3");
+
+        let w = SignedWad { val: BoundedInt::max(), sign: false };
+        let ww: SignedWad = StorePacking::unpack(StorePacking::pack(w));
+        assert_eq!(w, ww, "SignedWad packing 4");
+
+        let r = SignedRay { val: 123, sign: true };
+        let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
+        assert_eq!(r, rr, "SignedRay packing 1");
+
+        let r = SignedRay { val: 123, sign: false };
+        let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
+        assert_eq!(r, rr, "SignedRay packing 2");
+
+        let r = SignedRay { val: BoundedInt::max(), sign: true };
+        let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
+        assert_eq!(r, rr, "SignedRay packing 3");
+
+        let r = SignedRay { val: BoundedInt::max(), sign: false};
+        let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
+        assert_eq!(r, rr, "SignedRay packing 4");
     }
 }

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -500,7 +500,7 @@ mod test_wadray_signed {
         let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
         assert_eq!(r, rr, "SignedRay packing 3");
 
-        let r = SignedRay { val: BoundedInt::max(), sign: false};
+        let r = SignedRay { val: BoundedInt::max(), sign: false };
         let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
         assert_eq!(r, rr, "SignedRay packing 4");
     }

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -63,12 +63,13 @@ fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
 
 fn _pack(val: u128, sign: bool) -> felt252 {
     // shift by 2**128
-    val.into() + sign.into() * 0x100000000000000000000000000000000
+    let two_pow_128: felt252 = BoundedInt::<u128>::max().into() + 1;
+    val.into() + sign.into() * two_pow_128
 }
 
 fn _unpack(packed: felt252) -> (u128, bool) {
-    // 2**128
-    let shift: NonZero<u256> = u256_try_as_non_zero(0x100000000000000000000000000000000).unwrap();
+    let two_pow_128: u256 = BoundedInt::<u128>::max().into() + 1; // 2**128
+    let shift: NonZero<u256> = u256_try_as_non_zero(two_pow_128).unwrap();
     let (sign, val) = u256_safe_div_rem(packed.into(), shift);
     let val: u128 = val.try_into().expect('WadRay Signed val unpacking');
     let sign: u128 = sign.try_into().expect('WadRay Signed sign unpacking');

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,18 +1,18 @@
 use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
-use integer::BoundedInt;
+use integer::{BoundedInt, u256_safe_div_rem, u256_try_as_non_zero};
 use math::Oneable;
+use starknet::StorePacking;
 use wadray::wadray::{DIFF, Ray, RAY_ONE, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_ONE};
 
 const HALF_PRIME: felt252 = 1809251394333065606848661391547535052811553607665798349986546028067936010240;
 
-
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Copy, Drop, Serde)]
 struct SignedWad {
     val: u128,
     sign: bool
 }
 
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Copy, Drop, Serde)]
 struct SignedRay {
     val: u128,
     sign: bool
@@ -61,9 +61,46 @@ fn sign_from_mul(lhs_sign: bool, rhs_sign: bool) -> bool {
     lhs_sign ^ rhs_sign
 }
 
+fn _pack(val: u128, sign: bool) -> felt252 {
+    // shift by 2**128
+    val.into() + sign.into() * 0x100000000000000000000000000000000
+}
+
+fn _unpack(packed: felt252) -> (u128, bool) {
+    // 2**128
+    let shift: NonZero<u256> = u256_try_as_non_zero(0x100000000000000000000000000000000).unwrap();
+    let (sign, val) = u256_safe_div_rem(packed.into(), shift);
+    let val: u128 = val.try_into().expect('WadRay Signed val unpacking');
+    let sign: u128 = sign.try_into().expect('WadRay Signed sign unpacking');
+    (val, sign == 1)
+}
+
 //
 // Trait Implementations
 //
+
+// StorePacking
+impl SignedWadStorePacking of StorePacking<SignedWad, felt252> {
+    fn pack(value: SignedWad) -> felt252 {
+        _pack(value.val, value.sign)
+    }
+
+    fn unpack(value: felt252) -> SignedWad {
+        let (val, sign) = _unpack(value);
+        SignedWad { val, sign }
+    }
+}
+
+impl SignedRayStorePacking of StorePacking<SignedRay, felt252> {
+    fn pack(value: SignedRay) -> felt252 {
+        _pack(value.val, value.sign)
+    }
+
+    fn unpack(value: felt252) -> SignedRay {
+        let (val, sign) = _unpack(value);
+        SignedRay { val, sign }
+    }
+}
 
 // Addition
 impl SignedWadAdd of Add<SignedWad> {


### PR DESCRIPTION
Resolves #32.

I've added dependency on `starknet`. The lib had it implicitly because the types derived `starknet::Store` (now gone, any type that impls `StorePacking` can be stored), now it's explicit. Sucks a little because now it can't be used outside of Starknet without pulling in the dependency 😞 I guess the other option would be to create a wadray+starknet package and put the packing in there, but that's overengineering it IMO.