### PR TITLE
dev: using One and Zero traits

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -2,13 +2,13 @@ mod wadray;
 mod wadray_signed;
 
 use wadray::{
-    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOneable, RayZeroable,
+    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero,
     rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
-    WAD_SCALE, Wad, WadOneable, WadZeroable, wdiv_rw, wmul_rw, wmul_wr,
+    WAD_SCALE, Wad, WadOne, WadZero, wdiv_rw, wmul_rw, wmul_wr,
 };
 use wadray_signed::{
-    BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOneable, SignedRayZeroable, SignedWad,
-    SignedWadOneable, SignedWadZeroable, wad_to_signed_ray
+    BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOne, SignedRayZero, SignedWad,
+    SignedWadOne, SignedWadZero, wad_to_signed_ray
 };
 #[cfg(test)]
 mod tests {

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,4 +1,4 @@
-use math::Oneable;
+use core::num::traits::{One, Zero};
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
     WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
@@ -334,9 +334,9 @@ fn test_comparisons2() {
 }
 
 #[test]
-fn test_zeroable() {
+fn test_zero() {
     // Test zero
-    let wad_zero: Wad = Zeroable::zero();
+    let wad_zero: Wad = Zero::zero();
     assert_eq!(wad_zero.val, 0, "Value should be 0 #1");
 
     // Test is_zero
@@ -349,7 +349,7 @@ fn test_zeroable() {
     assert(wad_one.is_non_zero(), 'Value should not be 0 #5');
 
     // Test zero
-    let ray_zero: Ray = Zeroable::zero();
+    let ray_zero: Ray = Zero::zero();
     assert_eq!(ray_zero.val, 0, "Value should be 0 #6");
 
     // Test is_zero
@@ -363,13 +363,13 @@ fn test_zeroable() {
 }
 
 #[test]
-fn test_oneable() {
+fn test_one() {
     // Test one
-    let wad_one: Wad = Oneable::one();
+    let wad_one: Wad = One::one();
     assert_eq!(wad_one.val, 1000000000000000000, "Value should be WAD_ONE #1");
 
     // Test is_one
-    let wad_zero: Wad = Zeroable::zero();
+    let wad_zero: Wad = Zero::zero();
     assert(wad_one.is_one(), 'Value should be 1 #2');
     assert(!wad_zero.is_one(), 'Value should not be 1 #3');
 
@@ -378,11 +378,11 @@ fn test_oneable() {
     assert(wad_zero.is_non_one(), 'Value should not be 1 #5');
 
     // Test one
-    let ray_one: Ray = Oneable::one();
+    let ray_one: Ray = One::one();
     assert_eq!(ray_one.val, 1000000000000000000000000000, "Value should be RAY_ONE #6");
 
     // Test is_one
-    let ray_zero: Ray = Zeroable::zero();
+    let ray_zero: Ray = Zero::zero();
     assert(ray_one.is_one(), 'Value should be 1 #7');
     assert(!ray_zero.is_one(), 'Value should not be 1 #8');
 

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -1,10 +1,9 @@
 mod test_wadray_signed {
     use integer::BoundedInt;
-    use math::Oneable;
     use starknet::StorePacking;
     use wadray::{
-        BoundedSignedWad, BoundedSignedRay, DIFF, Ray, RAY_ONE, Signed, SignedRay, SignedRayOneable, SignedRayZeroable,
-        SignedWad, SignedWadOneable, SignedWadZeroable, Wad, WAD_ONE, wad_to_signed_ray
+        BoundedSignedWad, BoundedSignedRay, DIFF, Ray, RAY_ONE, Signed, SignedRay, SignedRayOne, SignedRayZero,
+        SignedWad, SignedWadOne, SignedWadZero, Wad, WAD_ONE, wad_to_signed_ray
     };
 
     #[test]
@@ -13,7 +12,7 @@ mod test_wadray_signed {
         let b = SignedWad { val: 100, sign: true };
         let c = SignedWad { val: 40, sign: true };
 
-        assert_eq!(a + b, SignedWadZeroable::zero(), "a + b != 0");
+        assert_eq!(a + b, SignedWadZero::zero(), "a + b != 0");
         assert_eq!(a - b, SignedWad { val: 200, sign: false }, "a - b != 200");
         assert_eq!(b - a, SignedWad { val: 200, sign: true }, "b - a != -200");
         assert_eq!(a + c, SignedWad { val: 60, sign: false }, "a + c != 60");
@@ -23,7 +22,7 @@ mod test_wadray_signed {
         let b = SignedRay { val: 100, sign: true };
         let c = SignedRay { val: 40, sign: true };
 
-        assert_eq!(a + b, SignedRayZeroable::zero(), "a + b != 0");
+        assert_eq!(a + b, SignedRayZero::zero(), "a + b != 0");
         assert_eq!(a - b, SignedRay { val: 200, sign: false }, "a - b != 200");
         assert_eq!(b - a, SignedRay { val: 200, sign: true }, "b - a != -200");
         assert_eq!(a + c, SignedRay { val: 60, sign: false }, "a + c != 60");
@@ -108,20 +107,20 @@ mod test_wadray_signed {
         let one = SignedWad { val: WAD_ONE, sign: false }; // 1.0 wad
         let neg_one = SignedWad { val: WAD_ONE, sign: true }; // -1.0 wad
 
-        assert_eq!((one * zero), SignedWadZeroable::zero(), "SignedWad zero mul #1");
-        assert_eq!((neg_one * zero), SignedWadZeroable::zero(), "SignedWad zero mul #2");
-        assert_eq!((one * neg_zero), SignedWadZeroable::zero(), "SignedWad zero mul #3");
-        assert_eq!((neg_one * neg_zero), SignedWadZeroable::zero(), "SignedWad zero mul #4");
+        assert_eq!((one * zero), SignedWadZero::zero(), "SignedWad zero mul #1");
+        assert_eq!((neg_one * zero), SignedWadZero::zero(), "SignedWad zero mul #2");
+        assert_eq!((one * neg_zero), SignedWadZero::zero(), "SignedWad zero mul #3");
+        assert_eq!((neg_one * neg_zero), SignedWadZero::zero(), "SignedWad zero mul #4");
 
         let zero = SignedRay { val: 0, sign: false };
         let neg_zero = SignedRay { val: 0, sign: true };
         let one = SignedRay { val: RAY_ONE, sign: false }; // 1.0 ray
         let neg_one = SignedRay { val: RAY_ONE, sign: true }; // -1.0 ray
 
-        assert_eq!((one * zero), SignedRayZeroable::zero(), "SignedRay zero mul #1");
-        assert_eq!((neg_one * zero), SignedRayZeroable::zero(), "SignedRay zero mul #2");
-        assert_eq!((one * neg_zero), SignedRayZeroable::zero(), "SignedRay zero mul #3");
-        assert_eq!((neg_one * neg_zero), SignedRayZeroable::zero(), "SignedRay zero mul #4");
+        assert_eq!((one * zero), SignedRayZero::zero(), "SignedRay zero mul #1");
+        assert_eq!((neg_one * zero), SignedRayZero::zero(), "SignedRay zero mul #2");
+        assert_eq!((one * neg_zero), SignedRayZero::zero(), "SignedRay zero mul #3");
+        assert_eq!((neg_one * neg_zero), SignedRayZero::zero(), "SignedRay zero mul #4");
     }
 
     #[test]
@@ -353,64 +352,64 @@ mod test_wadray_signed {
     }
 
     #[test]
-    fn test_zeroable_oneable() {
-        // Test SignedWadZeroable
-        let zero = SignedWadZeroable::zero();
-        assert_eq!(zero.val, 0, "Zeroable zero fail");
-        assert(!zero.sign, 'Zeroable zero sign fail');
-        assert(zero.is_zero(), 'Zeroable is_zero fail');
-        assert(!zero.is_non_zero(), 'Zeroable is_non_zero fail');
+    fn test_zero_one() {
+        // Test SignedWadZero
+        let zero = SignedWadZero::zero();
+        assert_eq!(zero.val, 0, "Zero zero fail");
+        assert(!zero.sign, 'Zero zero sign fail');
+        assert(zero.is_zero(), 'Zero is_zero fail');
+        assert(!zero.is_non_zero(), 'Zero is_non_zero fail');
 
         let non_zero = SignedWad { val: 100, sign: false };
-        assert(!non_zero.is_zero(), 'Zeroable non_zero fail');
-        assert(non_zero.is_non_zero(), 'Zeroable non_zero fail');
+        assert(!non_zero.is_zero(), 'Zero non_zero fail');
+        assert(non_zero.is_non_zero(), 'Zero non_zero fail');
 
-        // Test SignedWadOneable
-        let one = SignedWadOneable::one();
-        assert_eq!(one.val, WAD_ONE, "Oneable one fail");
-        assert(!one.sign, 'Oneable one sign fail');
-        assert(one.is_one(), 'Oneable is_one fail');
-        assert(!one.is_non_one(), 'Oneable is_non_one fail');
+        // Test SignedWadOne
+        let one = SignedWadOne::one();
+        assert_eq!(one.val, WAD_ONE, "One one fail");
+        assert(!one.sign, 'One one sign fail');
+        assert(one.is_one(), 'One is_one fail');
+        assert(!one.is_non_one(), 'One is_non_one fail');
 
         let minus_one = SignedWad { val: WAD_ONE, sign: true };
-        assert(!minus_one.is_one(), 'Oneable minus_one is_one fail');
-        assert(minus_one.is_non_one(), 'Oneable minus_one is_non_one f');
+        assert(!minus_one.is_one(), 'One minus_one is_one fail');
+        assert(minus_one.is_non_one(), 'One minus_one is_non_one f');
 
         let non_one = SignedWad { val: 200, sign: false };
-        assert(!non_one.is_one(), 'Oneable non_one fail');
-        assert(non_one.is_non_one(), 'Oneable non_one fail');
+        assert(!non_one.is_one(), 'One non_one fail');
+        assert(non_one.is_non_one(), 'One non_one fail');
 
-        // Test SignedRayZeroable
-        let zero = SignedRayZeroable::zero();
-        assert_eq!(zero.val, 0, "Zeroable zero fail");
-        assert(!zero.sign, 'Zeroable zero sign fail');
-        assert(zero.is_zero(), 'Zeroable is_zero fail');
-        assert(!zero.is_non_zero(), 'Zeroable is_non_zero fail');
+        // Test SignedRayZero
+        let zero = SignedRayZero::zero();
+        assert_eq!(zero.val, 0, "Zero zero fail");
+        assert(!zero.sign, 'Zero zero sign fail');
+        assert(zero.is_zero(), 'Zero is_zero fail');
+        assert(!zero.is_non_zero(), 'Zero is_non_zero fail');
 
         let non_zero = SignedRay { val: 100, sign: false };
-        assert(!non_zero.is_zero(), 'Zeroable non_zero fail');
-        assert(non_zero.is_non_zero(), 'Zeroable non_zero fail');
+        assert(!non_zero.is_zero(), 'Zero non_zero fail');
+        assert(non_zero.is_non_zero(), 'Zero non_zero fail');
 
-        // Test SignedRayOneable
-        let one = SignedRayOneable::one();
-        assert_eq!(one.val, RAY_ONE, "Oneable one fail");
-        assert(!one.sign, 'Oneable one sign fail');
-        assert(one.is_one(), 'Oneable is_one fail');
-        assert(!one.is_non_one(), 'Oneable is_non_one fail');
+        // Test SignedRayOne
+        let one = SignedRayOne::one();
+        assert_eq!(one.val, RAY_ONE, "One one fail");
+        assert(!one.sign, 'One one sign fail');
+        assert(one.is_one(), 'One is_one fail');
+        assert(!one.is_non_one(), 'One is_non_one fail');
 
         let minus_one = SignedRay { val: RAY_ONE, sign: true };
-        assert(!minus_one.is_one(), 'Oneable minus_one is_one fail');
-        assert(minus_one.is_non_one(), 'Oneable minus_one is_non_one f');
+        assert(!minus_one.is_one(), 'One minus_one is_one fail');
+        assert(minus_one.is_non_one(), 'One minus_one is_non_one f');
 
         let non_one = SignedRay { val: 200, sign: false };
-        assert(!non_one.is_one(), 'Oneable non_one fail');
-        assert(non_one.is_non_one(), 'Oneable non_one fail');
+        assert(!non_one.is_one(), 'One non_one fail');
+        assert(non_one.is_non_one(), 'One non_one fail');
     }
 
     #[test]
     fn test_signed() {
         // Test SignedWadSigned
-        let zero = SignedWadZeroable::zero();
+        let zero = SignedWadZero::zero();
         let one = SignedWad { val: 1, sign: false };
         let neg_one = SignedWad { val: 1, sign: true };
 
@@ -419,7 +418,7 @@ mod test_wadray_signed {
         assert(!neg_one.is_positive() && neg_one.is_negative(), 'Signed neg one fail');
 
         // Test SignedRaySigned
-        let zero = SignedRayZeroable::zero();
+        let zero = SignedRayZero::zero();
         let one = SignedRay { val: 1, sign: false };
         let neg_one = SignedRay { val: 1, sign: true };
 

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,6 +1,6 @@
 use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
+use core::num::traits::{One, Zero};
 use integer::BoundedInt;
-use math::Oneable;
 
 const WAD_DECIMALS: u8 = 18;
 const WAD_SCALE: u128 = 1000000000000000000;
@@ -402,74 +402,73 @@ impl BoundedRay of BoundedInt<Ray> {
     }
 }
 
-// Zeroable
-impl WadZeroable of Zeroable<Wad> {
+// Zero
+impl WadZero of Zero<Wad> {
     #[inline(always)]
     fn zero() -> Wad {
         Wad { val: 0 }
     }
 
     #[inline(always)]
-    fn is_zero(self: Wad) -> bool {
-        self.val == 0
+    fn is_zero(self: @Wad) -> bool {
+        *self.val == 0
     }
 
     #[inline(always)]
-    fn is_non_zero(self: Wad) -> bool {
-        self.val != 0
+    fn is_non_zero(self: @Wad) -> bool {
+        *self.val != 0
     }
 }
 
-impl RayZeroable of Zeroable<Ray> {
+impl RayZero of Zero<Ray> {
     #[inline(always)]
     fn zero() -> Ray {
         Ray { val: 0 }
     }
 
     #[inline(always)]
-    fn is_zero(self: Ray) -> bool {
-        self.val == 0
+    fn is_zero(self: @Ray) -> bool {
+        *self.val == 0
     }
 
     #[inline(always)]
-    fn is_non_zero(self: Ray) -> bool {
-        self.val != 0
+    fn is_non_zero(self: @Ray) -> bool {
+        *self.val != 0
     }
 }
 
-// Oneable
-
-impl WadOneable of Oneable<Wad> {
+// One
+impl WadOne of One<Wad> {
     #[inline(always)]
     fn one() -> Wad {
         Wad { val: WAD_ONE }
     }
 
     #[inline(always)]
-    fn is_one(self: Wad) -> bool {
-        self.val == WAD_ONE
+    fn is_one(self: @Wad) -> bool {
+        *self.val == WAD_ONE
     }
 
     #[inline(always)]
-    fn is_non_one(self: Wad) -> bool {
-        self.val != WAD_ONE
+    fn is_non_one(self: @Wad) -> bool {
+        *self.val != WAD_ONE
     }
 }
 
-impl RayOneable of Oneable<Ray> {
+impl RayOne of One<Ray> {
     #[inline(always)]
     fn one() -> Ray {
         Ray { val: RAY_ONE }
     }
 
     #[inline(always)]
-    fn is_one(self: Ray) -> bool {
-        self.val == RAY_ONE
+    fn is_one(self: @Ray) -> bool {
+        *self.val == RAY_ONE
     }
 
     #[inline(always)]
-    fn is_non_one(self: Ray) -> bool {
-        self.val != RAY_ONE
+    fn is_non_one(self: @Ray) -> bool {
+        *self.val != RAY_ONE
     }
 }
 

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,6 +1,6 @@
 use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
+use core::num::traits::{One, Zero};
 use integer::{BoundedInt, u256_safe_div_rem, u256_try_as_non_zero};
-use math::Oneable;
 use starknet::StorePacking;
 use wadray::wadray::{DIFF, Ray, RAY_ONE, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_ONE};
 
@@ -274,7 +274,7 @@ impl RayIntoSignedRay of Into<Ray, SignedRay> {
 
 impl SignedWadTryIntoWad of TryInto<SignedWad, Wad> {
     fn try_into(self: SignedWad) -> Option<Wad> {
-        if !self.sign || self.val.is_zero() {
+        if !self.sign || self.is_zero() {
             return Option::Some(Wad { val: self.val });
         } else {
             return Option::None;
@@ -284,7 +284,7 @@ impl SignedWadTryIntoWad of TryInto<SignedWad, Wad> {
 
 impl SignedRayTryIntoRay of TryInto<SignedRay, Ray> {
     fn try_into(self: SignedRay) -> Option<Ray> {
-        if !self.sign || self.val.is_zero() {
+        if !self.sign || self.is_zero() {
             return Option::Some(Ray { val: self.val });
         } else {
             return Option::None;
@@ -297,7 +297,7 @@ impl SignedRayTryIntoRay of TryInto<SignedRay, Ray> {
 impl SignedWadPartialEq of PartialEq<SignedWad> {
     fn eq(lhs: @SignedWad, rhs: @SignedWad) -> bool {
         let val_cmp: bool = *lhs.val == *rhs.val;
-        if val_cmp && (*lhs.val).is_zero() {
+        if val_cmp && lhs.is_zero() {
             true
         } else {
             val_cmp && *lhs.sign == *rhs.sign
@@ -350,7 +350,7 @@ impl SignedWadPartialOrd of PartialOrd<SignedWad> {
 impl SignedRayPartialEq of PartialEq<SignedRay> {
     fn eq(lhs: @SignedRay, rhs: @SignedRay) -> bool {
         let val_cmp: bool = *lhs.val == *rhs.val;
-        if val_cmp && (*lhs.val).is_zero() {
+        if val_cmp && lhs.is_zero() {
             true
         } else {
             val_cmp && *lhs.sign == *rhs.sign
@@ -427,74 +427,74 @@ impl BoundedSignedRay of BoundedInt<SignedRay> {
 }
 
 
-// Zeroable
-impl SignedWadZeroable of Zeroable<SignedWad> {
+// Zero
+impl SignedWadZero of Zero<SignedWad> {
     #[inline(always)]
     fn zero() -> SignedWad {
         SignedWad { val: 0, sign: false }
     }
 
     #[inline(always)]
-    fn is_zero(self: SignedWad) -> bool {
-        self.val == 0
+    fn is_zero(self: @SignedWad) -> bool {
+        *self.val == 0
     }
 
     #[inline(always)]
-    fn is_non_zero(self: SignedWad) -> bool {
-        self.val != 0
+    fn is_non_zero(self: @SignedWad) -> bool {
+        *self.val != 0
     }
 }
 
-impl SignedRayZeroable of Zeroable<SignedRay> {
+impl SignedRayZero of Zero<SignedRay> {
     #[inline(always)]
     fn zero() -> SignedRay {
         SignedRay { val: 0, sign: false }
     }
 
     #[inline(always)]
-    fn is_zero(self: SignedRay) -> bool {
-        self.val == 0
+    fn is_zero(self: @SignedRay) -> bool {
+        *self.val == 0
     }
 
     #[inline(always)]
-    fn is_non_zero(self: SignedRay) -> bool {
-        self.val != 0
+    fn is_non_zero(self: @SignedRay) -> bool {
+        *self.val != 0
     }
 }
 
 
-// Oneable
-impl SignedWadOneable of Oneable<SignedWad> {
+// One
+impl SignedWadOne of One<SignedWad> {
     #[inline(always)]
     fn one() -> SignedWad {
         SignedWad { val: WAD_ONE, sign: false }
     }
 
     #[inline(always)]
-    fn is_one(self: SignedWad) -> bool {
-        self.val == WAD_ONE && !self.sign
+    fn is_one(self: @SignedWad) -> bool {
+        *self.val == WAD_ONE && !*self.sign
     }
 
     #[inline(always)]
-    fn is_non_one(self: SignedWad) -> bool {
-        self.val != WAD_ONE || self.sign
+    fn is_non_one(self: @SignedWad) -> bool {
+        *self.val != WAD_ONE || *self.sign
     }
 }
 
-impl SignedRayOneable of Oneable<SignedRay> {
+impl SignedRayOne of One<SignedRay> {
     #[inline(always)]
     fn one() -> SignedRay {
         SignedRay { val: RAY_ONE, sign: false }
     }
 
     #[inline(always)]
-    fn is_one(self: SignedRay) -> bool {
-        self.val == RAY_ONE && !self.sign
+    fn is_one(self: @SignedRay) -> bool {
+        *self.val == RAY_ONE && !*self.sign
     }
 
     #[inline(always)]
-    fn is_non_one(self: SignedRay) -> bool {
-        self.val != RAY_ONE || self.sign
+    fn is_non_one(self: @SignedRay) -> bool {
+        *self.val != RAY_ONE || *self.sign
     }
 }
 


### PR DESCRIPTION
`One` and `Zero` are the public traits, preferable to `Oneable` and `Zeroable`, hence adopting them in this PR.