### PR TITLE
feat: clarify ray to wad truncation

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -2,7 +2,7 @@ mod wadray;
 mod wadray_signed;
 
 use wadray::{
-    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero, rdiv_wr,
+    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero, ray_to_wad, rdiv_wr,
     rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
     WAD_SCALE, Wad, WadOne, WadZero, wdiv_rw, wmul_rw, wmul_wr,
 };

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -2,9 +2,9 @@ mod wadray;
 mod wadray_signed;
 
 use wadray::{
-    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero, ray_to_wad, rdiv_wr,
-    rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE, WAD_PERCENT,
-    WAD_SCALE, Wad, WadOne, WadZero, wdiv_rw, wmul_rw, wmul_wr,
+    BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero,
+    ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE,
+    WAD_PERCENT, WAD_SCALE, Wad, WadOne, WadZero, wdiv_rw, wmul_rw, wmul_wr,
 };
 use wadray_signed::{
     BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOne, SignedRayZero, SignedWad, SignedWadOne,

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,6 +1,6 @@
 use core::num::traits::{One, Zero};
 use wadray::{
-    BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
+    BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
     WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
 };
 
@@ -246,8 +246,8 @@ fn test_conversions() {
     assert(a.is_none(), 'Incorrect wad->ray conversion');
 
     // Test conversion from Ray to Wad
-    let a: Wad = Ray { val: RAY_ONE }.into();
-    assert_eq!(a.val, WAD_ONE, "Incorrect ray->wad conversion");
+    let a: Ray = Ray { val: RAY_ONE };
+    assert_eq!(ray_to_wad(a).val, WAD_ONE, "Incorrect ray->wad conversion");
 }
 
 #[test]

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,7 +1,7 @@
 use core::num::traits::{One, Zero};
 use wadray::{
-    BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, Wad, WAD_ONE,
-    WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
+    BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,
+    Wad, WAD_ONE, WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
 };
 
 #[test]

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -263,12 +263,9 @@ impl WadTryIntoRay of TryInto<Wad, Ray> {
     }
 }
 
-impl RayIntoWad of Into<Ray, Wad> {
-    #[inline(always)]
-    fn into(self: Ray) -> Wad {
-        // The value will get truncated if it has more than 18 decimals.
-        Wad { val: self.val / DIFF }
-    }
+// Truncates a ray if it has more than 18 decimals.
+fn ray_to_wad(x: Ray) -> Wad {
+    Wad { val: x.val / DIFF }
 }
 
 impl TIntoWad<T, impl TIntoU128: Into<T, u128>> of Into<T, Wad> {

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -263,7 +263,7 @@ impl WadTryIntoRay of TryInto<Wad, Ray> {
     }
 }
 
-// Truncates a ray if it has more than 18 decimals.
+// Truncates a ray into a wad.
 fn ray_to_wad(x: Ray) -> Wad {
     Wad { val: x.val / DIFF }
 }


### PR DESCRIPTION
This PR replaces the `RayIntoWad` implementation with a `ray_to_wad` helper function that better suits the truncation behaviour that occurs when converting a Ray to a Wad.