### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Universal-Sierra-Compiler
         run: curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh -s -- v2.0.0
 
-      - uses: foundry-rs/setup-snfoundry@v2
+      - uses: foundry-rs/setup-snfoundry@v3
         with:
           starknet-foundry-version: "0.19.0"
       - run: snforge test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,6 @@ jobs:
       - run: scarb fmt --check
       - run: scarb build
 
-      - name: Install Universal-Sierra-Compiler
-        run: curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh -s -- v2.0.0
-
       - uses: foundry-rs/setup-snfoundry@v3
         with:
           starknet-foundry-version: "0.19.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.4.0"
+          scarb-version: "2.6.3"
       - run: scarb fmt --check
       - run: scarb build
 
+      - name: Install Universal-Sierra-Compiler
+        run: curl -L https://raw.githubusercontent.com/software-mansion/universal-sierra-compiler/master/scripts/install.sh | sh -s -- v2.0.0
+
       - uses: foundry-rs/setup-snfoundry@v2
         with:
-          starknet-foundry-version: "0.14.0"
+          starknet-foundry-version: "0.19.0"
       - run: snforge test

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,12 +3,12 @@ version = 1
 
 [[package]]
 name = "snforge_std"
-version = "0.14.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.14.0#e8cbecee4e31ed428c76d5173eaa90c8df796fe3"
+version = "0.19.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"
 
 [[package]]
 name = "wadray"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "snforge_std",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadray"
-version = "0.2.0"
-cairo-version = "2.4.0"
+version = "0.3.0"
+cairo-version = "2.6.3"
 authors = ["Lindy Labs"]
 description = "Fixed-point decimal numbers for Cairo"
 readme = "README.md"
@@ -10,10 +10,10 @@ license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
 [dependencies]
-starknet = ">= 2.4"
+starknet = ">= 2.6.3"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.14.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }
 
 [lib]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadray"
 version = "0.3.0"
-cairo-version = "2.6.3"
+cairo-version = "2.6.0"
 authors = ["Lindy Labs"]
 description = "Fixed-point decimal numbers for Cairo"
 readme = "README.md"
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
 [dependencies]
-starknet = ">= 2.6.3"
+starknet = ">= 2.6.0"
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -222,13 +222,13 @@ fn test_div_of_0() {
 }
 
 #[test]
-#[should_panic(expected: ('u256 is 0',))]
+#[should_panic(expected: ('Division by 0',))]
 fn test_div_wad_fail() {
     let _: Wad = Wad { val: WAD_ONE } / Wad { val: 0 };
 }
 
 #[test]
-#[should_panic(expected: ('u256 is 0',))]
+#[should_panic(expected: ('Division by 0',))]
 fn test_div_ray_fail() {
     let _: Ray = Ray { val: RAY_ONE } / Ray { val: 0 };
 }

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -124,35 +124,35 @@ mod test_wadray_signed {
     }
 
     #[test]
-    #[should_panic(expected: 'u256 is 0')]
+    #[should_panic(expected: 'Division by 0')]
     fn test_signed_wad_zero_div() {
         let zero = SignedWad { val: 0, sign: false };
         let one = SignedWad { val: WAD_ONE, sign: false };
-        let res: SignedWad = one / zero;
+        let _: SignedWad = one / zero;
     }
 
     #[test]
-    #[should_panic(expected: 'u256 is 0')]
+    #[should_panic(expected: 'Division by 0')]
     fn test_signed_wad_neg_zero_div() {
         let neg_zero = SignedWad { val: 0, sign: true };
         let one = SignedWad { val: WAD_ONE, sign: false };
-        let res: SignedWad = one / neg_zero;
+        let _: SignedWad = one / neg_zero;
     }
 
     #[test]
-    #[should_panic(expected: 'u256 is 0')]
+    #[should_panic(expected: 'Division by 0')]
     fn test_signed_ray_zero_div() {
         let zero = SignedRay { val: 0, sign: false };
         let one = SignedRay { val: RAY_ONE, sign: false };
-        let res: SignedRay = one / zero;
+        let _: SignedRay = one / zero;
     }
 
     #[test]
-    #[should_panic(expected: 'u256 is 0')]
+    #[should_panic(expected: 'Division by 0')]
     fn test_signed_ray_neg_zero_div() {
         let neg_zero = SignedRay { val: 0, sign: true };
         let one = SignedRay { val: RAY_ONE, sign: false };
-        let res: SignedRay = one / neg_zero;
+        let _: SignedRay = one / neg_zero;
     }
 
     #[test]
@@ -275,7 +275,6 @@ mod test_wadray_signed {
     #[test]
     fn test_bounded() {
         let max_u128 = 0xffffffffffffffffffffffffffffffff;
-        let one = SignedWad { val: WAD_ONE, sign: false };
         let neg_one = SignedWad { val: WAD_ONE, sign: true };
 
         assert_eq!(BoundedSignedWad::min(), SignedWad { val: max_u128, sign: true }, "SignedWad min");
@@ -284,7 +283,6 @@ mod test_wadray_signed {
         assert_eq!((BoundedSignedWad::min() * neg_one), BoundedSignedWad::max(), "SignedWad min mul");
         assert_eq!((BoundedSignedWad::max() * neg_one), BoundedSignedWad::min(), "SignedWad max mul");
 
-        let one = SignedRay { val: RAY_ONE, sign: false };
         let neg_one = SignedRay { val: RAY_ONE, sign: true };
 
         assert_eq!(BoundedSignedRay::min(), SignedRay { val: max_u128, sign: true }, "SignedRay min");

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -530,7 +530,7 @@ impl SignedRaySigned of Signed<SignedRay> {
 impl DisplaySignedWad of Display<SignedWad> {
     fn fmt(self: @SignedWad, ref f: Formatter) -> Result<(), Error> {
         if *self.sign {
-            write!(f, "-");
+            write!(f, "-")?;
         }
 
         Display::fmt(self.val, ref f)
@@ -540,7 +540,7 @@ impl DisplaySignedWad of Display<SignedWad> {
 impl DisplaySignedRay of Display<SignedRay> {
     fn fmt(self: @SignedRay, ref f: Formatter) -> Result<(), Error> {
         if *self.sign {
-            write!(f, "-");
+            write!(f, "-")?;
         }
 
         Display::fmt(self.val, ref f)


### PR DESCRIPTION
This PR bumps Cairo and related dependencies to `v2.6.3`.