### PR TITLE
feat: default & neg traits

### DIFF
--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,3 +1,4 @@
+use core::traits::Default;
 use core::num::traits::{One, Zero};
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,
@@ -400,4 +401,13 @@ fn test_display_and_debug() {
     let r = Ray { val: 456 };
     assert_eq!(format!("{}", r), "456", "Ray display");
     assert_eq!(format!("{:?}", r), "456", "Ray debug");
+}
+
+#[test]
+fn test_default() {
+    let w: Wad = Default::default();
+    assert_eq!(w.val, 0, "Wad default");
+
+    let r: Ray = Default::default();
+    assert_eq!(r.val, 0, "Ray default");
 }

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,4 +1,3 @@
-use core::traits::Default;
 use core::num::traits::{One, Zero};
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -1,5 +1,4 @@
 mod test_wadray_signed {
-    use core::traits::Default;
     use core::num::traits::Bounded;
     use starknet::storage_access::StorePacking;
     use wadray::{
@@ -512,5 +511,32 @@ mod test_wadray_signed {
         let r: SignedRay = Default::default();
         assert_eq!(r.val, 0, "SignedRay default val");
         assert!(r.sign == false, "SignedRay default sign");
+    }
+
+    #[test]
+    fn test_neg() {
+        let wp = SignedWad { val: 123, sign: false };
+        let wpn = -wp;
+        assert_eq!(wpn.val, 123, "SignedWad neg val");
+        assert!(wpn.sign, "SignedWad neg sign");
+        assert_eq!(-wpn, wp, "SignedWad double neg");
+
+        let wp0 = SignedWad { val: 0, sign: false };
+        let wpn0 = -wp0;
+        assert_eq!(wpn0.val, 0, "SignedWad zero neg val");
+        assert!(wpn0.sign, "SignedWad zero neg sign");
+        assert_eq!(-wpn0, wp0, "SignedWad zero double neg");
+
+        let rp = SignedRay { val: 123, sign: false };
+        let rpn = -rp;
+        assert_eq!(rpn.val, 123, "SignedRay neg val");
+        assert!(rpn.sign, "SignedRay neg sign");
+        assert_eq!(-rpn, rp, "SignedRay double neg");
+
+        let rp0 = SignedRay { val: 0, sign: false };
+        let rpn0 = -rp0;
+        assert_eq!(rpn0.val, 0, "SignedRay zero neg val");
+        assert!(rpn0.sign, "SignedRay zero neg sign");
+        assert_eq!(-rpn0, rp0, "SignedRay zero double neg");
     }
 }

--- a/src/tests/test_wadray_signed.cairo
+++ b/src/tests/test_wadray_signed.cairo
@@ -1,4 +1,5 @@
 mod test_wadray_signed {
+    use core::traits::Default;
     use core::num::traits::Bounded;
     use starknet::storage_access::StorePacking;
     use wadray::{
@@ -500,5 +501,16 @@ mod test_wadray_signed {
         let r = SignedRay { val: Bounded::MAX, sign: false };
         let rr: SignedRay = StorePacking::unpack(StorePacking::pack(r));
         assert_eq!(r, rr, "SignedRay packing 4");
+    }
+
+    #[test]
+    fn test_default() {
+        let w: SignedWad = Default::default();
+        assert_eq!(w.val, 0, "SignedWad default val");
+        assert!(w.sign == false, "SignedWad default sign");
+
+        let r: SignedRay = Default::default();
+        assert_eq!(r.val, 0, "SignedRay default val");
+        assert!(r.sign == false, "SignedRay default sign");
     }
 }

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,3 +1,4 @@
+use core::traits::Default;
 use core::fmt::{Debug, Display, Error, Formatter};
 use core::num::traits::{One, Zero, Bounded};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
@@ -480,5 +481,18 @@ pub impl DebugWad of Debug<Wad> {
 pub impl DebugRay of Debug<Ray> {
     fn fmt(self: @Ray, ref f: Formatter) -> Result<(), Error> {
         Display::fmt(self, ref f)
+    }
+}
+
+// Default
+pub impl DefaultWad of Default<Wad> {
+    fn default() -> Wad {
+        Wad { val: 0 }
+    }
+}
+
+pub impl DefaultRay of Default<Ray> {
+    fn default() -> Ray {
+        Ray { val: 0 }
     }
 }

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,7 +1,7 @@
-use core::traits::Default;
 use core::fmt::{Debug, Display, Error, Formatter};
 use core::num::traits::{One, Zero, Bounded};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
+use core::traits::Default;
 
 
 pub const WAD_DECIMALS: u8 = 18;

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,4 +1,4 @@
-use core::traits::Default;
+use core::traits::{Default, Neg};
 use core::fmt::{Debug, Display, Error, Formatter};
 use core::num::traits::{One, Zero, Bounded};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
@@ -557,5 +557,19 @@ pub impl DefaultSignedWad of Default<SignedWad> {
 pub impl DefaultSignedRay of Default<SignedRay> {
     fn default() -> SignedRay {
         SignedRay { val: 0, sign: false }
+    }
+}
+
+// Neg
+pub impl SignedWadNeg of Neg<SignedWad> {
+    fn neg(a: SignedWad) -> SignedWad {
+        SignedWad { val: a.val, sign: !a.sign }
+    }
+}
+
+
+pub impl SignedRayNeg of Neg<SignedRay> {
+    fn neg(a: SignedRay) -> SignedRay {
+        SignedRay { val: a.val, sign: !a.sign }
     }
 }

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,7 +1,7 @@
-use core::traits::{Default, Neg};
 use core::fmt::{Debug, Display, Error, Formatter};
 use core::num::traits::{One, Zero, Bounded};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
+use core::traits::{Default, Neg};
 use starknet::storage_access::StorePacking;
 use wadray::wadray::{DIFF, Ray, RAY_ONE, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, Wad, WAD_ONE};
 

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -1,3 +1,4 @@
+use core::traits::Default;
 use core::fmt::{Debug, Display, Error, Formatter};
 use core::num::traits::{One, Zero, Bounded};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
@@ -543,5 +544,18 @@ pub impl DebugSignedWad of Debug<SignedWad> {
 pub impl DebugSignedRay of Debug<SignedRay> {
     fn fmt(self: @SignedRay, ref f: Formatter) -> Result<(), Error> {
         Display::fmt(self, ref f)
+    }
+}
+
+// Default
+pub impl DefaultSignedWad of Default<SignedWad> {
+    fn default() -> SignedWad {
+        SignedWad { val: 0, sign: false }
+    }
+}
+
+pub impl DefaultSignedRay of Default<SignedRay> {
+    fn default() -> SignedRay {
+        SignedRay { val: 0, sign: false }
     }
 }


### PR DESCRIPTION
PR implements the `Default` trait for all types and `Neg` trait (ability to do `-foo`) for SignedWad and SignedRay.
