### PR TITLE
feat: add conversion to u128; modify wad to ray conversion

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,7 +4,7 @@ pub mod wadray_signed;
 pub use wadray::{
     BoundedWad, BoundedRay, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, RAY_PERCENT, RAY_SCALE, Ray, RayOne, RayZero,
     ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr, u128_rdiv, u128_rmul, u128_wdiv, u128_wmul, WAD_DECIMALS, WAD_ONE,
-    WAD_PERCENT, WAD_SCALE, Wad, WadOne, WadZero, wdiv_rw, wmul_rw, wmul_wr,
+    WAD_PERCENT, WAD_SCALE, Wad, WadOne, WadZero, wad_to_ray, wdiv_rw, wmul_rw, wmul_wr,
 };
 pub use wadray_signed::{
     BoundedSignedRay, BoundedSignedWad, Signed, SignedRay, SignedRayOne, SignedRayZero, SignedWad, SignedWadOne,

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -277,9 +277,11 @@ fn test_bounded() {
 }
 
 #[test]
-fn test_wadray_into_u256() {
+fn test_wadray_into_unsigned() {
+    // Test WadIntoU128
+    assert_eq!(Wad { val: 5 }.into(), 5_u128, "Incorrect Wad->u256 conversion");
     // Test WadIntoU256
-    assert_eq!(Wad { val: 5 }.into(), 5_u256, "Incorrect Wad->u256 conversion")
+    assert_eq!(Wad { val: 5 }.into(), 5_u256, "Incorrect Wad->u256 conversion");
 }
 
 #[test]

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,7 +1,7 @@
 use core::num::traits::{One, Zero};
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,
-    Wad, WAD_ONE, WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
+    Wad, WAD_ONE, WAD_DECIMALS, WAD_SCALE, wad_to_ray, wdiv_rw, wmul_rw, wmul_wr,
 };
 
 #[test]
@@ -236,13 +236,13 @@ fn test_div_ray_fail() {
 #[test]
 fn test_conversions() {
     // Test conversion from Wad to Ray
-    let a: Ray = Wad { val: WAD_ONE }.try_into().unwrap();
+    let a: Ray = wad_to_ray(Wad { val: WAD_ONE }).unwrap();
     assert_eq!(a.val, RAY_ONE, "Incorrect wad->ray conversion");
 
-    let a: Ray = Wad { val: MAX_CONVERTIBLE_WAD }.try_into().unwrap();
+    let a: Ray = wad_to_ray(Wad { val: MAX_CONVERTIBLE_WAD }).unwrap();
     assert_eq!(a.val, MAX_CONVERTIBLE_WAD * DIFF, "Incorrect wad->ray conversion");
 
-    let a: Option::<Ray> = Wad { val: MAX_CONVERTIBLE_WAD + 1 }.try_into();
+    let a: Option::<Ray> = wad_to_ray(Wad { val: MAX_CONVERTIBLE_WAD + 1 });
     assert(a.is_none(), 'Incorrect wad->ray conversion');
 
     // Test conversion from Ray to Wad
@@ -288,12 +288,6 @@ fn test_wadray_into_unsigned() {
 fn test_u256_try_into_wadray() {
     // Test U256TryIntoWad
     assert_eq!(Wad { val: 5 }, 5_u256.try_into().unwrap(), "Incorrect u256->Wad conversion");
-}
-
-#[test]
-#[should_panic(expected: ('Option::unwrap failed.',))]
-fn test_conversions_fail2() {
-    let _: Ray = Wad { val: MAX_CONVERTIBLE_WAD + 1 }.try_into().unwrap();
 }
 
 // comparison tests are split into 2 fns to overcome a test runner bug

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -284,6 +284,13 @@ pub impl TIntoRay<T, impl TIntoU128: Into<T, u128>> of Into<T, Ray> {
     }
 }
 
+pub impl WadIntoU128 of Into<Wad, u128> {
+    #[inline]
+    fn into(self: Wad) -> u128 {
+        self.val
+    }
+}
+
 pub impl WadIntoFelt252 of Into<Wad, felt252> {
     #[inline]
     fn into(self: Wad) -> felt252 {
@@ -295,6 +302,13 @@ pub impl WadIntoU256 of Into<Wad, u256> {
     #[inline]
     fn into(self: Wad) -> u256 {
         self.val.into()
+    }
+}
+
+pub impl RayIntoU128 of Into<Ray, u128> {
+    #[inline]
+    fn into(self: Ray) -> u128 {
+        self.val
     }
 }
 

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -255,13 +255,11 @@ pub impl RayDivAssign of DivAssign<Ray, Ray> {
 
 
 // Conversions
-pub impl WadTryIntoRay of TryInto<Wad, Ray> {
-    fn try_into(self: Wad) -> Option::<Ray> {
-        if (self.val <= MAX_CONVERTIBLE_WAD) {
-            Option::Some(Ray { val: self.val * DIFF })
-        } else {
-            Option::None
-        }
+pub fn wad_to_ray(x: Wad) -> Option<Ray> {
+    if (x.val <= MAX_CONVERTIBLE_WAD) {
+        Option::Some(Ray { val: x.val * DIFF })
+    } else {
+        Option::None
     }
 }
 

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -21,12 +21,12 @@ pub(crate) const DIFF: u128 = 1000000000;
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct Wad {
-    pub(crate) val: u128,
+    pub val: u128,
 }
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct Ray {
-    pub(crate) val: u128
+    pub val: u128
 }
 
 // Core functions

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -21,12 +21,12 @@ pub(crate) const DIFF: u128 = 1000000000;
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct Wad {
-    pub val: u128,
+    pub(crate) val: u128,
 }
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct Ray {
-    pub val: u128
+    pub(crate) val: u128
 }
 
 // Core functions

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -9,14 +9,14 @@ const HALF_PRIME: u256 = 1809251394333065606848661391547535052811553607665798349
 
 #[derive(Copy, Drop, Serde)]
 pub struct SignedWad {
-    pub val: u128,
-    pub sign: bool
+    pub(crate) val: u128,
+    pub(crate) sign: bool
 }
 
 #[derive(Copy, Drop, Serde)]
 pub struct SignedRay {
-    pub val: u128,
-    pub sign: bool
+    pub(crate) val: u128,
+    pub(crate) sign: bool
 }
 
 // External helpers

--- a/src/wadray_signed.cairo
+++ b/src/wadray_signed.cairo
@@ -9,14 +9,14 @@ const HALF_PRIME: u256 = 1809251394333065606848661391547535052811553607665798349
 
 #[derive(Copy, Drop, Serde)]
 pub struct SignedWad {
-    pub(crate) val: u128,
-    pub(crate) sign: bool
+    pub val: u128,
+    pub sign: bool
 }
 
 #[derive(Copy, Drop, Serde)]
 pub struct SignedRay {
-    pub(crate) val: u128,
-    pub(crate) sign: bool
+    pub val: u128,
+    pub sign: bool
 }
 
 // External helpers


### PR DESCRIPTION
~~This PR relaxes the crate visibility for members of the custom type structs, as they may need to be accessed directly by users downstream.~~

This PR implements `Into<Wad, u128>` and `Into<Ray, u128>`. It also removes `TryInto<Wad, Ray>` in favour of a `wad_to_ray` helper function, which is necessary to prevent two different paths for converting wad to ray.