### PR TITLE
feat: implement Sqrt for wadray

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -14,4 +14,5 @@ pub use wadray_signed::{
 mod tests {
     mod test_wadray;
     mod test_wadray_signed;
+    pub mod utils;
 }

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,4 +1,5 @@
-use core::num::traits::{One, Zero};
+use core::num::traits::{One, Bounded, Sqrt, Zero};
+use wadray::tests::utils::assert_equalish;
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,
     Wad, WAD_ONE, WAD_DECIMALS, WAD_SCALE, wdiv_rw, wmul_rw, wmul_wr,
@@ -389,6 +390,54 @@ fn test_one() {
     // Test is_non_one
     assert(!ray_one.is_non_one(), 'Value should be 1 #9');
     assert(ray_zero.is_non_one(), 'Value should not be 1 #10');
+}
+
+#[test]
+fn test_sqrt() {
+    let ERROR_MARGIN: Ray = 1_u128.into();
+
+    let val: Ray = Zero::zero();
+    let sqrt: Ray = Sqrt::sqrt(val);
+    assert(sqrt.val == Zero::zero(), 'wrong sqrt #1');
+
+    // Ground truth tests
+
+    // 1000
+    let val: Ray = 1000000000000000000000000000000_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 31622776601683793319988935444_u128.into(), ERROR_MARGIN, 'wrong sqrt #2');
+
+    // 6969
+    let val: Ray = 6969000000000000000000000000000_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 83480536653761396384637711221_u128.into(), ERROR_MARGIN, 'wrong sqrt #3');
+
+    // pi
+    let val: Ray = 3141592653589793238462643383_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 1772453850905516027298167483_u128.into(), ERROR_MARGIN, 'wrong sqrt #4');
+
+    // e
+    let val: Ray = 2718281828459045235360287471_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 1648721270700128146848650787_u128.into(), ERROR_MARGIN, 'wrong sqrt #5');
+
+    // Testing the property x = sqrt(x)^2
+
+    let ERROR_MARGIN: Ray = 1000_u128.into();
+
+    let val: Ray = (4 * RAY_ONE).into();
+    let sqrt: Ray = Sqrt::sqrt(val);
+    assert_equalish((4 * RAY_ONE).into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #6');
+
+    let val: Ray = (1000 * RAY_ONE).into();
+    let sqrt: Ray = Sqrt::sqrt(val);
+    assert_equalish((1000 * RAY_ONE).into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #7');
+
+    // tau
+    let val: Ray = 6283185307179586476925286766_u128.into();
+    let sqrt: Ray = Sqrt::sqrt(val);
+    assert_equalish(6283185307179586476925286766_u128.into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #8');
+
+    // testing the maximum possible value `sqrt` could accept doesn't cause it to fail
+    let val: Ray = Bounded::MAX;
+    Sqrt::sqrt(val);
 }
 
 #[test]

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -393,7 +393,55 @@ fn test_one() {
 }
 
 #[test]
-fn test_sqrt() {
+fn test_sqrt_wad() {
+    let ERROR_MARGIN: Wad = 1_u128.into();
+
+    let val: Wad = Zero::zero();
+    let sqrt: Wad = Sqrt::sqrt(val);
+    assert(sqrt.val == Zero::zero(), 'wrong sqrt #1');
+
+    // Ground truth tests
+
+    // 1000
+    let val: Wad = 1000000000000000000000_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 31622776601683793319_u128.into(), ERROR_MARGIN, 'wrong sqrt #2');
+
+    // 6969
+    let val: Wad = 6969000000000000000000_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 83480536653761396384_u128.into(), ERROR_MARGIN, 'wrong sqrt #3');
+
+    // pi
+    let val: Wad = 3141592653589793238_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 1772453850905516027_u128.into(), ERROR_MARGIN, 'wrong sqrt #4');
+
+    // e
+    let val: Wad = 2718281828459045235_u128.into();
+    assert_equalish(Sqrt::sqrt(val), 1648721270700128146_u128.into(), ERROR_MARGIN, 'wrong sqrt #5');
+
+    // Testing the property x = sqrt(x)^2
+
+    let ERROR_MARGIN: Wad = 1000_u128.into();
+
+    let val: Wad = (4 * WAD_ONE).into();
+    let sqrt: Wad = Sqrt::sqrt(val);
+    assert_equalish((4 * WAD_ONE).into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #6');
+
+    let val: Wad = (1000 * WAD_ONE).into();
+    let sqrt: Wad = Sqrt::sqrt(val);
+    assert_equalish((1000 * WAD_ONE).into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #7');
+
+    // tau
+    let val: Wad = 6283185307179586476_u128.into();
+    let sqrt: Wad = Sqrt::sqrt(val);
+    assert_equalish(6283185307179586476_u128.into(), sqrt * sqrt, ERROR_MARGIN, 'wrong sqrt #8');
+
+    // testing the maximum possible value `sqrt` could accept doesn't cause it to fail
+    let val: Wad = Bounded::MAX;
+    Sqrt::sqrt(val);
+}
+
+#[test]
+fn test_sqrt_ray() {
     let ERROR_MARGIN: Ray = 1_u128.into();
 
     let val: Ray = Zero::zero();

--- a/src/tests/utils.cairo
+++ b/src/tests/utils.cairo
@@ -1,0 +1,9 @@
+pub fn assert_equalish<T, impl TPartialOrd: PartialOrd<T>, impl TSub: Sub<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>>(
+    a: T, b: T, error: T, message: felt252
+) {
+    if a >= b {
+        assert(a - b <= error, message);
+    } else {
+        assert(b - a <= error, message);
+    }
+}

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -460,6 +460,15 @@ pub impl RayOne of One<Ray> {
 }
 
 // Square root
+pub impl WadSqrt of Sqrt<Wad> {
+    type Target = Wad;
+    #[inline]
+    fn sqrt(self: Wad) -> Wad {
+        let scaled_val: u256 = self.val.into() * WAD_SCALE.into();
+        Sqrt::sqrt(scaled_val).into()
+    }
+}
+
 pub impl RaySqrt of Sqrt<Ray> {
     type Target = Ray;
     #[inline]

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,5 +1,5 @@
 use core::fmt::{Debug, Display, Error, Formatter};
-use core::num::traits::{One, Zero, Bounded};
+use core::num::traits::{Bounded, One, Sqrt, Zero};
 use core::ops::{AddAssign, SubAssign, MulAssign, DivAssign};
 use core::traits::Default;
 
@@ -458,6 +458,17 @@ pub impl RayOne of One<Ray> {
         *self.val != RAY_ONE
     }
 }
+
+// Square root
+pub impl RaySqrt of Sqrt<Ray> {
+    type Target = Ray;
+    #[inline]
+    fn sqrt(self: Ray) -> Ray {
+        let scaled_val: u256 = self.val.into() * RAY_SCALE.into();
+        Sqrt::sqrt(scaled_val).into()
+    }
+}
+
 
 // Display and Debug
 pub impl DisplayWad of Display<Wad> {


### PR DESCRIPTION
This PR implements the `sqrt` function for `Ray` originally set out [here](https://github.com/lindy-labs/opus_contracts/blob/5808049618f9c53e0747969ac6e2c7104b6d47b3/src/utils/math.cairo#L9).

Should we implement `Sqrt` trait for `Wad` too?