### PR TITLE
chore: bump dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.7.0
-starknet-foundry 0.27.0
+scarb 2.8.4
+starknet-foundry 0.31.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,9 +2,19 @@
 version = 1
 
 [[package]]
+name = "snforge_scarb_plugin"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
+
+[[package]]
 name = "snforge_std"
-version = "0.27.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.27.0#2d99b7c00678ef0363881ee0273550c44a9263de"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+dependencies = [
+ "snforge_scarb_plugin",
+]
 
 [[package]]
 name = "wadray"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wadray"
 version = "0.5.0"
-cairo-version = "2.7.0"
+cairo-version = "2.8.0"
 edition = "2024_07"
 authors = ["Lindy Labs"]
 description = "Fixed-point decimal numbers for Cairo"
@@ -11,11 +11,11 @@ license-file = "LICENSE"
 keywords = ["fixed-point", "wad", "ray", "cairo", "starknet"]
 
 [dependencies]
-starknet = ">= 2.7.0"
+starknet = ">= 2.8.0"
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.27.0" }
-assert_macros = "0.1.0"
+snforge_std = ">= 0.31.0"
+assert_macros = ">= 2.8.0"
 
 [lib]
 sierra-text = true

--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -2,7 +2,7 @@ use core::num::traits::{One, Bounded, Sqrt, Zero};
 use wadray::tests::utils::assert_equalish;
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, Ray, RAY_ONE, ray_to_wad, rdiv_wr, rdiv_ww, rmul_rw, rmul_wr,
-    Wad, WAD_ONE, WAD_DECIMALS, WAD_SCALE, wad_to_ray, wdiv_rw, wmul_rw, wmul_wr,
+    Wad, WAD_ONE, wad_to_ray, wdiv_rw, wmul_rw, wmul_wr,
 };
 
 #[test]


### PR DESCRIPTION
This PR upgrades the dependencies to latest Scarb/Cairo due to issues with publishing.