### PR TITLE
feat: implement Pow

### DIFF
--- a/src/tests/test_wadray.cairo
+++ b/src/tests/test_wadray.cairo
@@ -1,4 +1,4 @@
-use core::num::traits::{Bounded, One, Sqrt, Zero};
+use core::num::traits::{Bounded, One, Pow, Sqrt, Zero};
 use wadray::tests::utils::assert_equalish;
 use wadray::{
     BoundedRay, BoundedWad, DIFF, MAX_CONVERTIBLE_WAD, RAY_ONE, Ray, WAD_ONE, Wad, ray_to_wad, rdiv_wr, rdiv_ww,
@@ -482,6 +482,28 @@ fn test_sqrt_ray() {
     // testing the maximum possible value `sqrt` could accept doesn't cause it to fail
     let val: Ray = Bounded::MAX;
     Sqrt::sqrt(val);
+}
+
+#[test]
+fn test_pow_wad() {
+    let ERROR_MARGIN: Wad = 1000_u128.into();
+
+    let val: Wad = 3141592653589793238_u128.into();
+    assert_equalish(val.pow(2), 9869604401089358615_u128.into(), ERROR_MARGIN, 'wrong pow wad#1');
+
+    let val: Wad = 1414213562373095048_u128.into();
+    assert_equalish(val.pow(4), (4 * WAD_ONE).into(), ERROR_MARGIN, 'wrong pow wad #2');
+}
+
+#[test]
+fn test_pow_ray() {
+    let ERROR_MARGIN: Ray = 1000_u128.into();
+
+    let val: Ray = 3141592653589793238462643383_u128.into();
+    assert_equalish(val.pow(2), 9869604401089358618834490999_u128.into(), ERROR_MARGIN, 'wrong pow ray #1');
+
+    let val: Ray = 1414213562373095048801688724_u128.into();
+    assert_equalish(val.pow(4), (4 * RAY_ONE).into(), ERROR_MARGIN, 'wrong pow ray #2');
 }
 
 #[test]

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -1,5 +1,5 @@
 use core::fmt::{Debug, Display, Error, Formatter};
-use core::num::traits::{Bounded, One, Sqrt, Zero};
+use core::num::traits::{Bounded, One, Pow, Sqrt, Zero};
 use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 use core::traits::Default;
 
@@ -490,6 +490,34 @@ pub impl RaySqrt of Sqrt<Ray> {
     }
 }
 
+// Pow
+fn pow<T, impl TMul: Mul<T>, impl TOne: One<T>, impl TDrop: Drop<T>, impl TCopy: Copy<T>>(x: T, mut n: usize) -> T {
+    if n == 0 {
+        TOne::one()
+    } else if n == 1 {
+        x
+    } else if n % 2 == 0 {
+        pow(x * x, n / 2)
+    } else {
+        x * pow(x * x, (n - 1) / 2)
+    }
+}
+
+pub impl PowWad of Pow<Wad, usize> {
+    type Output = Wad;
+
+    fn pow(self: Wad, exp: usize) -> Wad {
+        pow(self, exp)
+    }
+}
+
+pub impl PowRay of Pow<Ray, usize> {
+    type Output = Ray;
+
+    fn pow(self: Ray, exp: usize) -> Ray {
+        pow(self, exp)
+    }
+}
 
 // Display and Debug
 pub impl DisplayWad of Display<Wad> {

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -514,6 +514,7 @@ pub impl PowWad of Pow<Wad, usize> {
 pub impl PowRay of Pow<Ray, usize> {
     type Output = Ray;
 
+    // For `self < 1`, the error is bounded by `exp / RAY_SCALE`.
     fn pow(self: Ray, exp: usize) -> Ray {
         pow(self, exp)
     }

--- a/src/wadray.cairo
+++ b/src/wadray.cairo
@@ -514,7 +514,7 @@ pub impl PowWad of Pow<Wad, usize> {
 pub impl PowRay of Pow<Ray, usize> {
     type Output = Ray;
 
-    // For `self < 1`, the error is bounded by `exp / RAY_SCALE`.
+    // For `self < RAY_ONE`, the error is bounded by `exp / RAY_SCALE`.
     fn pow(self: Ray, exp: usize) -> Ray {
         pow(self, exp)
     }


### PR DESCRIPTION
This PR implements the `Pow` trait for wadray by migrating the `pow` function from [Opus](https://github.com/lindy-labs/opus_contracts/blob/110fd9ba2cf8492928bc86074dfe490c5784b560/src/utils/math.cairo#L12-L22). 